### PR TITLE
[feat/live-chat-support] Add support chat feature (backend + frontend)

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/controller/AdminChatController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/AdminChatController.java
@@ -1,0 +1,62 @@
+package org.example.backend.controller;
+
+import jakarta.validation.Valid;
+import org.example.backend.dto.request.ChatSendMessageRequestDto;
+import org.example.backend.dto.response.ChatMessageResponseDto;
+import org.example.backend.dto.response.ChatThreadResponseDto;
+import org.example.backend.service.ChatService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/chats")
+public class AdminChatController {
+
+    private final ChatService chatService;
+
+    public AdminChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping
+    public List<ChatThreadResponseDto> listThreads(
+            @RequestParam(required = false) String query,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return chatService.listThreads(query, clampLimit(limit));
+    }
+
+    @GetMapping("/{threadId}/messages")
+    public List<ChatMessageResponseDto> getThreadMessages(
+            @PathVariable Long threadId,
+            @RequestParam(required = false) Long afterId,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return chatService.getMessagesForThread(threadId, afterId, clampLimit(limit));
+    }
+
+    @PostMapping("/{threadId}/messages")
+    public ChatMessageResponseDto sendAdminMessage(
+            @PathVariable Long threadId,
+            @Valid @RequestBody ChatSendMessageRequestDto req
+    ) {
+        return chatService.sendAdminMessage(currentUserId(), threadId, req.getContent());
+    }
+
+    private int clampLimit(int limit) {
+        if (limit < 1) return 1;
+        if (limit > 200) return 200;
+        return limit;
+    }
+
+    private long currentUserId() {
+        var a = org.springframework.security.core.context.SecurityContextHolder
+                .getContext().getAuthentication();
+        Object p = (a != null) ? a.getPrincipal() : null;
+        if (p instanceof Long l) return l;
+        if (p instanceof Integer i) return i.longValue();
+        if (p instanceof String s) return Long.parseLong(s);
+        throw new IllegalStateException("No authenticated principal userId");
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/controller/ChatController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/ChatController.java
@@ -1,0 +1,57 @@
+package org.example.backend.controller;
+
+import jakarta.validation.Valid;
+import org.example.backend.dto.request.ChatSendMessageRequestDto;
+import org.example.backend.dto.response.ChatMessageResponseDto;
+import org.example.backend.dto.response.ChatThreadResponseDto;
+import org.example.backend.service.ChatService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    public ChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping("/thread/me")
+    public ChatThreadResponseDto getMyThread() {
+        return chatService.getOrCreateThreadForUser(currentUserId());
+    }
+
+    @GetMapping("/messages/me")
+    public List<ChatMessageResponseDto> getMyMessages(
+            @RequestParam(required = false) Long afterId,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return chatService.getMessagesForUser(currentUserId(), afterId, clampLimit(limit));
+    }
+
+    @PostMapping("/messages/me")
+    public ChatMessageResponseDto sendMyMessage(
+            @Valid @RequestBody ChatSendMessageRequestDto req
+    ) {
+        return chatService.sendUserMessage(currentUserId(), req.getContent());
+    }
+
+    private int clampLimit(int limit) {
+        if (limit < 1) return 1;
+        if (limit > 200) return 200;
+        return limit;
+    }
+
+    private long currentUserId() {
+        var a = org.springframework.security.core.context.SecurityContextHolder
+                .getContext().getAuthentication();
+        Object p = (a != null) ? a.getPrincipal() : null;
+        if (p instanceof Long l) return l;
+        if (p instanceof Integer i) return i.longValue();
+        if (p instanceof String s) return Long.parseLong(s);
+        throw new IllegalStateException("No authenticated principal userId");
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/dto/request/ChatSendMessageRequestDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/request/ChatSendMessageRequestDto.java
@@ -1,0 +1,14 @@
+package org.example.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ChatSendMessageRequestDto {
+
+    @NotBlank
+    private String content;
+
+    public ChatSendMessageRequestDto() {}
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+}

--- a/backend/backend/src/main/java/org/example/backend/dto/response/ChatMessageResponseDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/ChatMessageResponseDto.java
@@ -1,0 +1,31 @@
+package org.example.backend.dto.response;
+
+import java.time.OffsetDateTime;
+
+public class ChatMessageResponseDto {
+    private long id;
+    private String senderRole;   // PASSENGER/DRIVER/ADMIN
+    private String content;
+    private OffsetDateTime sentAt;
+
+    public ChatMessageResponseDto() {}
+
+    public ChatMessageResponseDto(long id, String senderRole, String content, OffsetDateTime sentAt) {
+        this.id = id;
+        this.senderRole = senderRole;
+        this.content = content;
+        this.sentAt = sentAt;
+    }
+
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+
+    public String getSenderRole() { return senderRole; }
+    public void setSenderRole(String senderRole) { this.senderRole = senderRole; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public OffsetDateTime getSentAt() { return sentAt; }
+    public void setSentAt(OffsetDateTime sentAt) { this.sentAt = sentAt; }
+}

--- a/backend/backend/src/main/java/org/example/backend/dto/response/ChatThreadResponseDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/ChatThreadResponseDto.java
@@ -1,0 +1,26 @@
+package org.example.backend.dto.response;
+
+import java.time.OffsetDateTime;
+
+public class ChatThreadResponseDto {
+    private long id;
+    private long userId;
+    private OffsetDateTime lastMessageAt;
+
+    public ChatThreadResponseDto() {}
+
+    public ChatThreadResponseDto(long id, long userId, OffsetDateTime lastMessageAt) {
+        this.id = id;
+        this.userId = userId;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+
+    public long getUserId() { return userId; }
+    public void setUserId(long userId) { this.userId = userId; }
+
+    public OffsetDateTime getLastMessageAt() { return lastMessageAt; }
+    public void setLastMessageAt(OffsetDateTime lastMessageAt) { this.lastMessageAt = lastMessageAt; }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/ChatRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/ChatRepository.java
@@ -1,0 +1,24 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.ChatMessageResponseDto;
+import org.example.backend.dto.response.ChatThreadResponseDto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRepository {
+
+    Optional<ChatThreadResponseDto> findThreadByUserId(long userId);
+
+    ChatThreadResponseDto createThreadForUser(long userId);
+
+    Optional<ChatThreadResponseDto> findThreadById(long threadId);
+
+    List<ChatThreadResponseDto> listThreads(String query, int limit);
+
+    List<ChatMessageResponseDto> findMessages(long threadId, Long afterId, int limit);
+
+    ChatMessageResponseDto insertMessage(long threadId, long senderUserId, String senderRole, String content);
+
+    boolean touchThreadLastMessageAt(long threadId);
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcChatRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcChatRepository.java
@@ -1,0 +1,171 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.ChatMessageResponseDto;
+import org.example.backend.dto.response.ChatThreadResponseDto;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class JdbcChatRepository implements ChatRepository {
+
+    private final JdbcClient jdbc;
+
+    public JdbcChatRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public Optional<ChatThreadResponseDto> findThreadByUserId(long userId) {
+        return jdbc.sql("""
+            select id, user_id, last_message_at
+            from chat_threads
+            where user_id = :userId
+        """)
+                .param("userId", userId)
+                .query((rs, rn) -> new ChatThreadResponseDto(
+                        rs.getLong("id"),
+                        rs.getLong("user_id"),
+                        rs.getObject("last_message_at", OffsetDateTime.class)
+                ))
+                .optional();
+    }
+
+    @Override
+    public ChatThreadResponseDto createThreadForUser(long userId) {
+        Long id = jdbc.sql("""
+            insert into chat_threads (user_id, created_at, last_message_at)
+            values (:userId, now(), null)
+            returning id
+        """)
+                .param("userId", userId)
+                .query(Long.class)
+                .single();
+
+        return new ChatThreadResponseDto(id, userId, null);
+    }
+
+    @Override
+    public Optional<ChatThreadResponseDto> findThreadById(long threadId) {
+        return jdbc.sql("""
+            select id, user_id, last_message_at
+            from chat_threads
+            where id = :id
+        """)
+                .param("id", threadId)
+                .query((rs, rn) -> new ChatThreadResponseDto(
+                        rs.getLong("id"),
+                        rs.getLong("user_id"),
+                        rs.getObject("last_message_at", OffsetDateTime.class)
+                ))
+                .optional();
+    }
+
+    @Override
+    public List<ChatThreadResponseDto> listThreads(String query, int limit) {
+        String q = (query == null) ? "" : query.trim().toLowerCase();
+
+        return jdbc.sql("""
+            select ct.id, ct.user_id, ct.last_message_at
+            from chat_threads ct
+            join users u on u.id = ct.user_id
+            where (:q = '' or
+                   lower(u.email) like ('%' || :q || '%') or
+                   lower(u.first_name) like ('%' || :q || '%') or
+                   lower(u.last_name) like ('%' || :q || '%'))
+            order by ct.last_message_at desc nulls last, ct.id desc
+            limit :limit
+        """)
+                .param("q", q)
+                .param("limit", limit)
+                .query((rs, rn) -> new ChatThreadResponseDto(
+                        rs.getLong("id"),
+                        rs.getLong("user_id"),
+                        rs.getObject("last_message_at", OffsetDateTime.class)
+                ))
+                .list();
+    }
+
+    @Override
+    public List<ChatMessageResponseDto> findMessages(long threadId, Long afterId, int limit) {
+        if (afterId == null) {
+            List<ChatMessageResponseDto> desc = jdbc.sql("""
+                select id, sender_role, content, sent_at
+                from chat_messages
+                where thread_id = :threadId
+                order by id desc
+                limit :limit
+            """)
+                    .param("threadId", threadId)
+                    .param("limit", limit)
+                    .query((rs, rn) -> new ChatMessageResponseDto(
+                            rs.getLong("id"),
+                            rs.getString("sender_role"),
+                            rs.getString("content"),
+                            rs.getObject("sent_at", OffsetDateTime.class)
+                    ))
+                    .list();
+
+            // vrati u asc da frontu bude prirodno
+            List<ChatMessageResponseDto> asc = new ArrayList<>(desc.size());
+            for (int i = desc.size() - 1; i >= 0; i--) asc.add(desc.get(i));
+            return asc;
+        }
+
+        return jdbc.sql("""
+            select id, sender_role, content, sent_at
+            from chat_messages
+            where thread_id = :threadId
+              and id > :afterId
+            order by id asc
+            limit :limit
+        """)
+                .param("threadId", threadId)
+                .param("afterId", afterId)
+                .param("limit", limit)
+                .query((rs, rn) -> new ChatMessageResponseDto(
+                        rs.getLong("id"),
+                        rs.getString("sender_role"),
+                        rs.getString("content"),
+                        rs.getObject("sent_at", OffsetDateTime.class)
+                ))
+                .list();
+    }
+
+    @Override
+    public ChatMessageResponseDto insertMessage(long threadId, long senderUserId, String senderRole, String content) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        Long id = jdbc.sql("""
+            insert into chat_messages (thread_id, sender_user_id, sender_role, content, sent_at)
+            values (:threadId, :senderUserId, :senderRole, :content, :sentAt)
+            returning id
+        """)
+                .param("threadId", threadId)
+                .param("senderUserId", senderUserId)
+                .param("senderRole", senderRole)
+                .param("content", content)
+                .param("sentAt", now)
+                .query(Long.class)
+                .single();
+
+        return new ChatMessageResponseDto(id, senderRole, content, now);
+    }
+
+    @Override
+    public boolean touchThreadLastMessageAt(long threadId) {
+        int updated = jdbc.sql("""
+            update chat_threads
+            set last_message_at = now()
+            where id = :id
+        """)
+                .param("id", threadId)
+                .update();
+
+        return updated > 0;
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcUserLookupRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcUserLookupRepository.java
@@ -35,6 +35,19 @@ public class JdbcUserLookupRepository implements UserLookupRepository {
     }
 
     @Override
+    public Optional<String> findRoleById(Long id) {
+        return jdbc.sql("""
+        select role
+        from users
+        where id = :id
+    """)
+                .param("id", id)
+                .query(String.class)
+                .optional();
+    }
+
+
+    @Override
     public Optional<UserBasic> findByEmail(String email) {
         return jdbc.sql("""
             select id, email, first_name, last_name, is_active, blocked, block_reason

--- a/backend/backend/src/main/java/org/example/backend/repository/UserLookupRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/UserLookupRepository.java
@@ -17,4 +17,6 @@ public interface UserLookupRepository {
     Optional<UserBasic> findById(Long id);
 
     Optional<UserBasic> findByEmail(String email);
+    Optional<String> findRoleById(Long id);
+
 }

--- a/backend/backend/src/main/java/org/example/backend/security/SecurityConfig.java
+++ b/backend/backend/src/main/java/org/example/backend/security/SecurityConfig.java
@@ -39,6 +39,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/registration/**").permitAll()
                         .requestMatchers("/error").permitAll()
+
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
                         .anyRequest().authenticated()
                 )
 

--- a/backend/backend/src/main/java/org/example/backend/service/ChatService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/ChatService.java
@@ -1,0 +1,106 @@
+package org.example.backend.service;
+
+import org.example.backend.dto.response.ChatMessageResponseDto;
+import org.example.backend.dto.response.ChatThreadResponseDto;
+import org.example.backend.repository.ChatRepository;
+import org.example.backend.repository.UserLookupRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final UserLookupRepository userLookupRepository;
+
+    public ChatService(ChatRepository chatRepository, UserLookupRepository userLookupRepository) {
+        this.chatRepository = chatRepository;
+        this.userLookupRepository = userLookupRepository;
+    }
+
+    public ChatThreadResponseDto getOrCreateThreadForUser(long userId) {
+        // validacija: user postoji
+        userLookupRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        return chatRepository.findThreadByUserId(userId)
+                .orElseGet(() -> {
+                    try {
+                        return chatRepository.createThreadForUser(userId);
+                    } catch (DataIntegrityViolationException e) {
+                        // ako se paralelno kreira thread (unique user_id)
+                        return chatRepository.findThreadByUserId(userId)
+                                .orElseThrow(() -> new ResponseStatusException(
+                                        HttpStatus.INTERNAL_SERVER_ERROR, "Chat thread create failed"
+                                ));
+                    }
+                });
+    }
+
+    public List<ChatMessageResponseDto> getMessagesForUser(long userId, Long afterId, int limit) {
+        ChatThreadResponseDto thread = getOrCreateThreadForUser(userId);
+        return chatRepository.findMessages(thread.getId(), afterId, limit);
+    }
+
+    public ChatMessageResponseDto sendUserMessage(long userId, String content) {
+        String text = normalizeContent(content);
+
+        String role = userLookupRepository.findRoleById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        // ovaj endpoint je za putnika/vozača
+        if (!"PASSENGER".equals(role) && !"DRIVER".equals(role)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only passengers/drivers can send messages here");
+        }
+
+        ChatThreadResponseDto thread = getOrCreateThreadForUser(userId);
+
+        ChatMessageResponseDto msg = chatRepository.insertMessage(thread.getId(), userId, role, text);
+        chatRepository.touchThreadLastMessageAt(thread.getId());
+        return msg;
+    }
+
+    public List<ChatThreadResponseDto> listThreads(String query, int limit) {
+        return chatRepository.listThreads(query, limit);
+    }
+
+    public List<ChatMessageResponseDto> getMessagesForThread(long threadId, Long afterId, int limit) {
+        chatRepository.findThreadById(threadId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Thread not found"));
+
+        return chatRepository.findMessages(threadId, afterId, limit);
+    }
+
+    public ChatMessageResponseDto sendAdminMessage(long adminUserId, long threadId, String content) {
+        String text = normalizeContent(content);
+
+        String role = userLookupRepository.findRoleById(adminUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (!"ADMIN".equals(role)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Admin only");
+        }
+
+        chatRepository.findThreadById(threadId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Thread not found"));
+
+        ChatMessageResponseDto msg = chatRepository.insertMessage(threadId, adminUserId, "ADMIN", text);
+        chatRepository.touchThreadLastMessageAt(threadId);
+        return msg;
+    }
+
+    private String normalizeContent(String content) {
+        String text = (content == null) ? "" : content.trim();
+        if (text.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Message content is empty");
+        }
+        if (text.length() > 2000) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Message content too long");
+        }
+        return text;
+    }
+}

--- a/backend/backend/src/main/resources/db/migration/V27__chat.sql
+++ b/backend/backend/src/main/resources/db/migration/V27__chat.sql
@@ -1,0 +1,27 @@
+-- V10__chat.sql
+
+create table if not exists chat_threads (
+                                            id              bigserial primary key,
+                                            user_id         bigint not null unique references users(id) on delete cascade,
+    created_at      timestamptz not null default now(),
+    last_message_at timestamptz
+    );
+
+create index if not exists idx_chat_threads_last_message_at
+    on chat_threads(last_message_at desc nulls last);
+
+create table if not exists chat_messages (
+                                             id              bigserial primary key,
+                                             thread_id       bigint not null references chat_threads(id) on delete cascade,
+    sender_user_id  bigint references users(id) on delete set null,
+    sender_role     varchar(20) not null,
+    content         text not null,
+    sent_at         timestamptz not null default now()
+    );
+
+create index if not exists idx_chat_messages_thread_id_id
+    on chat_messages(thread_id, id);
+
+alter table chat_messages
+    add constraint chat_messages_sender_role_chk
+        check (sender_role in ('PASSENGER','DRIVER','ADMIN'));

--- a/frontend/ddn-frontend/src/app/api/chat/chat.datasource.ts
+++ b/frontend/ddn-frontend/src/app/api/chat/chat.datasource.ts
@@ -1,0 +1,17 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ChatMessageResponse, ChatSendMessageRequest, ChatThreadResponse } from './models/chat.models';
+
+export interface ChatDataSource {
+  // user
+  getMyThread(): Observable<ChatThreadResponse>;
+  getMyMessages(afterId: number | null, limit: number): Observable<ChatMessageResponse[]>;
+  sendMyMessage(body: ChatSendMessageRequest): Observable<ChatMessageResponse>;
+
+  // admin
+  listThreads(query: string | null, limit: number): Observable<ChatThreadResponse[]>;
+  getThreadMessages(threadId: number, afterId: number | null, limit: number): Observable<ChatMessageResponse[]>;
+  sendAdminMessage(threadId: number, body: ChatSendMessageRequest): Observable<ChatMessageResponse>;
+}
+
+export const CHAT_DS = new InjectionToken<ChatDataSource>('CHAT_DS');

--- a/frontend/ddn-frontend/src/app/api/chat/chat.http.datasource.ts
+++ b/frontend/ddn-frontend/src/app/api/chat/chat.http.datasource.ts
@@ -1,0 +1,45 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { API_BASE_URL } from '../../app.config';
+import { ChatDataSource } from './chat.datasource';
+import { ChatMessageResponse, ChatSendMessageRequest, ChatThreadResponse } from './models/chat.models';
+
+@Injectable()
+export class ChatHttpDataSource implements ChatDataSource {
+  private http = inject(HttpClient);
+  private readonly baseUrl = inject(API_BASE_URL);
+
+  // user
+  getMyThread(): Observable<ChatThreadResponse> {
+    return this.http.get<ChatThreadResponse>(`${this.baseUrl}/chat/thread/me`);
+  }
+
+  getMyMessages(afterId: number | null, limit: number): Observable<ChatMessageResponse[]> {
+    let params = new HttpParams().set('limit', String(limit));
+    if (afterId != null) params = params.set('afterId', String(afterId));
+    return this.http.get<ChatMessageResponse[]>(`${this.baseUrl}/chat/messages/me`, { params });
+  }
+
+  sendMyMessage(body: ChatSendMessageRequest): Observable<ChatMessageResponse> {
+    return this.http.post<ChatMessageResponse>(`${this.baseUrl}/chat/messages/me`, body);
+  }
+
+  // admin
+  listThreads(query: string | null, limit: number): Observable<ChatThreadResponse[]> {
+    let params = new HttpParams().set('limit', String(limit));
+    if (query && query.trim().length > 0) params = params.set('query', query.trim());
+    return this.http.get<ChatThreadResponse[]>(`${this.baseUrl}/admin/chats`, { params });
+  }
+
+  getThreadMessages(threadId: number, afterId: number | null, limit: number): Observable<ChatMessageResponse[]> {
+    let params = new HttpParams().set('limit', String(limit));
+    if (afterId != null) params = params.set('afterId', String(afterId));
+    return this.http.get<ChatMessageResponse[]>(`${this.baseUrl}/admin/chats/${threadId}/messages`, { params });
+  }
+
+  sendAdminMessage(threadId: number, body: ChatSendMessageRequest): Observable<ChatMessageResponse> {
+    return this.http.post<ChatMessageResponse>(`${this.baseUrl}/admin/chats/${threadId}/messages`, body);
+  }
+}

--- a/frontend/ddn-frontend/src/app/api/chat/models/chat.models.ts
+++ b/frontend/ddn-frontend/src/app/api/chat/models/chat.models.ts
@@ -1,0 +1,16 @@
+export type ChatThreadResponse = {
+  id: number;
+  userId: number;
+  lastMessageAt: string | null;
+};
+
+export type ChatMessageResponse = {
+  id: number;
+  senderRole: 'PASSENGER' | 'DRIVER' | 'ADMIN';
+  content: string;
+  sentAt: string;
+};
+
+export type ChatSendMessageRequest = {
+  content: string;
+};

--- a/frontend/ddn-frontend/src/app/app.routes.ts
+++ b/frontend/ddn-frontend/src/app/app.routes.ts
@@ -37,6 +37,8 @@ import { RideLifecycleHttpDataSource } from './api/driver/ride-lifecycle.http.da
 // guards
 import { authGuard } from './api/auth/auth.guard';
 import { roleGuard } from './api/auth/role.guard';
+import { ChatHttpDataSource } from './api/chat/chat.http.datasource';
+import { CHAT_DS } from './api/chat/chat.datasource';
 
 export const routes: Routes = [
   { path: '', component: LandingComponent },
@@ -82,6 +84,13 @@ export const routes: Routes = [
     canActivate: [authGuard, roleGuard],
     data: { roles: ['PASSENGER'] },
     children: [
+{
+  path: 'support',
+  loadComponent: () => import('./pages/user/user-chat/user-chat').then(m => m.UserChat),
+  providers: [{ provide: CHAT_DS, useClass: ChatHttpDataSource }],
+},
+
+
       {
         path: 'home',
         loadComponent: () =>
@@ -148,6 +157,17 @@ export const routes: Routes = [
     canActivate: [authGuard, roleGuard],
     data: { roles: ['ADMIN'] },
     children: [
+      {
+  path: 'chats',
+  loadComponent: () => import('./pages/admin/admin-chats/admin-chats').then(m => m.AdminChats),
+  providers: [{ provide: CHAT_DS, useClass: ChatHttpDataSource }],
+},
+{
+  path: 'chats/:threadId',
+  loadComponent: () => import('./pages/admin/admin-chat-details/admin-chat-details').then(m => m.AdminChatDetails),
+  providers: [{ provide: CHAT_DS, useClass: ChatHttpDataSource }],
+},
+
       { path: 'home', component: AdminHome },
       { path: 'update-requests', component: AdminUpdateRequests },
       { path: 'create-driver', component: AdminCreateDriver },

--- a/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.css
@@ -76,14 +76,19 @@
   border: 1px solid #444;
   border-radius: 6px;
   font-weight: 300;
+
+  background: rgba(255, 255, 255, 0.08); /* TAMNO default */
+  color: #fff;
+
   transition: all 0.2s ease;
 }
 
 .logout-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.16); /* SVETLIJE na hover */
   border-color: #666;
   opacity: 1;
 }
+
 
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);

--- a/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.html
+++ b/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.html
@@ -11,6 +11,9 @@
     <a class="nav-link" routerLink="/admin/create-driver" routerLinkActive="active">
       Create Driver
     </a>
+    <a class="nav-link" routerLink="/admin/chats" routerLinkActive="active">
+  Chats
+</a>
 
 
     <a class="nav-link" routerLink="/admin/reports" routerLinkActive="active">

--- a/frontend/ddn-frontend/src/app/components/navbar/navbar.css
+++ b/frontend/ddn-frontend/src/app/components/navbar/navbar.css
@@ -33,22 +33,31 @@
   justify-content: flex-end;
 }
 
+/* ===== LINKS ===== */
+
 .nav-link {
   color: white;
   text-decoration: none;
   font-size: 20px;
   font-weight: 100;
   cursor: pointer;
+
   padding: 6px 14px;
   display: inline-flex;
   align-items: center;
+
   transition: opacity 0.2s ease;
   position: relative;
+
+  background: transparent;
+  opacity: 1;
 }
 
 .nav-link:hover {
   opacity: 0.8;
 }
+
+/* ===== ACTIVE LINK ===== */
 
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);
@@ -68,6 +77,8 @@
   border-radius: 2px;
 }
 
+/* ===== PANIC BUTTON ===== */
+
 .panic-btn {
   width: 73px;
   height: 34px;
@@ -84,7 +95,8 @@
   display: block;
 }
 
-/* STATUS */
+/* ===== DRIVER STATUS ===== */
+
 .driver-status {
   font-size: 14px;
   padding: 4px 12px;
@@ -100,15 +112,27 @@
   border-color: #2ecc71;
 }
 
-.logout-btn {
+/* ===== LOGOUT BUTTON (FIXED) ===== */
+
+.nav-link.logout-btn {
   border: 1px solid #444;
   border-radius: 6px;
   font-weight: 300;
+
+  background: rgba(255, 255, 255, 0.08); /* TAMNO DEFAULT */
+  color: #fff;
+
+  opacity: 1;
   transition: all 0.2s ease;
 }
 
-.logout-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+.nav-link.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.16); /* SVETLIJE NA HOVER */
   border-color: #666;
   opacity: 1;
+}
+
+/* HARD OVERRIDE ZA <button> */
+button.logout-btn {
+  background-color: rgba(255, 255, 255, 0.08);
 }

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
@@ -37,6 +37,23 @@
   justify-content: flex-end;
 }
 
+/* ===== UNIFIED NAV ITEMS (KLJUČNO) ===== */
+
+.nav-link,
+.nav-link.logout-btn {
+  height: 36px;              /* ISTA VISINA SVUDA */
+  line-height: 36px;         /* ISTA TEKST VERTIKALA */
+  padding: 0 14px;           /* UJEDNAČEN PADDING */
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: border-box;
+}
+
+/* ===== LINKS ===== */
+
 .nav-link {
   color: white;
   text-decoration: none;
@@ -44,17 +61,18 @@
   font-weight: 100;
   cursor: pointer;
 
-  padding: 6px 14px;
-  display: inline-flex;
-  align-items: center;
-
   transition: opacity 0.2s ease;
   position: relative;
+
+  background: transparent;
+  opacity: 1;
 }
 
 .nav-link:hover {
   opacity: 0.8;
 }
+
+/* ===== PANIC BUTTON ===== */
 
 .panic-btn {
   width: 73px;
@@ -72,18 +90,37 @@
   display: block;
 }
 
-.logout-btn {
+/* ===== LOGOUT BUTTON ===== */
+
+.nav-link.logout-btn {
   border: 1px solid #444;
   border-radius: 6px;
   font-weight: 300;
+
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+
+  opacity: 1;
   transition: all 0.2s ease;
 }
 
-.logout-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+/* oduzimamo border od visine da bude ISTO */
+.nav-link.logout-btn {
+  height: 36px;
+}
+
+.nav-link.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
   border-color: #666;
   opacity: 1;
 }
+
+/* HARD OVERRIDE ZA <button> */
+button.logout-btn {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+/* ===== ACTIVE LINK ===== */
 
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.css
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.css
@@ -1,0 +1,67 @@
+.content { padding: 24px; box-sizing: border-box; font-family: 'Montserrat', sans-serif; color: #fff; }
+
+.top { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.back { color: #cfcfcf; text-decoration: none; font-size: 12px; }
+.back:hover { color: #fff; }
+.title { font-weight: 800; font-size: 14px; }
+
+.card {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  background: rgba(0,0,0,0.6);
+  padding: 14px;
+}
+
+.chat {
+  height: 60vh;
+  overflow: auto;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  background: #111;
+  padding: 12px;
+}
+
+.row { display: flex; margin: 10px 0; }
+.row.admin { justify-content: flex-end; }
+
+.bubble {
+  max-width: min(520px, 85%);
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.06);
+}
+.row.admin .bubble { background: rgba(47,47,47,0.9); }
+
+.meta { display: flex; gap: 10px; justify-content: space-between; margin-bottom: 6px; }
+.role { font-size: 11px; color: #cfcfcf; font-weight: 700; }
+.time { font-size: 11px; color: #9a9a9a; }
+.text { font-size: 13px; line-height: 1.35; white-space: pre-wrap; }
+
+.composer { margin-top: 12px; display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+
+.input {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #3a3a3a;
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  padding: 0 12px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  outline: none;
+}
+
+.btn {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #444;
+  background: #2f2f2f;
+  color: #fff;
+  cursor: pointer;
+  padding: 0 16px;
+  font-size: 13px;
+}
+.btn:hover { background: #3a3a3a; border-color: #3a3a3a; }
+
+.hint { color: #cfcfcf; font-size: 12px; }

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.html
@@ -1,0 +1,27 @@
+<div class="content">
+  <div class="top">
+    <a class="back" routerLink="/admin/chats">← Back</a>
+    <div class="title">Thread #{{ threadId }}</div>
+  </div>
+
+  <div class="card">
+    <div *ngIf="loading" class="hint">Loading...</div>
+
+    <div class="chat" id="admin-chat-scroll" *ngIf="!loading">
+      <div *ngFor="let m of messages" class="row" [class.admin]="m.senderRole === 'ADMIN'">
+        <div class="bubble">
+          <div class="meta">
+            <span class="role">{{ m.senderRole }}</span>
+            <span class="time">{{ m.sentAt | date:'short' }}</span>
+          </div>
+          <div class="text">{{ m.content }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <input class="input" [(ngModel)]="input" placeholder="Type a reply..." (keydown.enter)="send()" />
+      <button class="btn" (click)="send()">Send</button>
+    </div>
+  </div>
+</div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chat-details/admin-chat-details.ts
@@ -1,0 +1,90 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+
+import { CHAT_DS } from '../../../api/chat/chat.datasource';
+import { ChatMessageResponse } from '../../../api/chat/models/chat.models';
+
+@Component({
+  selector: 'app-admin-chat-details',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './admin-chat-details.html',
+  styleUrl: './admin-chat-details.css',
+})
+export class AdminChatDetails implements OnInit, OnDestroy {
+  private ds = inject(CHAT_DS);
+  private route = inject(ActivatedRoute);
+
+  threadId = 0;
+  messages: ChatMessageResponse[] = [];
+  input = '';
+  loading = true;
+
+  private pollTimer: any = null;
+  private lastId: number | null = null;
+
+  ngOnInit(): void {
+    this.threadId = Number(this.route.snapshot.paramMap.get('threadId') ?? '0');
+    this.loadInitial();
+  }
+
+  ngOnDestroy(): void {
+    if (this.pollTimer != null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  send(): void {
+    const text = this.input.trim();
+    if (!text) return;
+    this.input = '';
+
+    this.ds.sendAdminMessage(this.threadId, { content: text }).subscribe({
+      next: (msg) => {
+        this.messages = [...this.messages, msg];
+        this.lastId = msg.id;
+        this.scrollToBottomSoon();
+      },
+    });
+  }
+
+  private loadInitial(): void {
+    this.loading = true;
+    this.ds.getThreadMessages(this.threadId, null, 50).subscribe({
+      next: (msgs) => {
+        this.messages = msgs ?? [];
+        this.lastId = this.messages.length ? this.messages[this.messages.length - 1].id : null;
+        this.loading = false;
+        this.startPolling();
+        this.scrollToBottomSoon();
+      },
+      error: () => (this.loading = false),
+    });
+  }
+
+  private startPolling(): void {
+    if (this.pollTimer != null) return;
+
+    this.pollTimer = setInterval(() => {
+      const after = this.lastId;
+      this.ds.getThreadMessages(this.threadId, after, 50).subscribe({
+        next: (newMsgs) => {
+          if (!newMsgs || newMsgs.length === 0) return;
+          this.messages = [...this.messages, ...newMsgs];
+          this.lastId = newMsgs[newMsgs.length - 1].id;
+          this.scrollToBottomSoon();
+        },
+      });
+    }, 2500);
+  }
+
+  private scrollToBottomSoon(): void {
+    setTimeout(() => {
+      const el = document.getElementById('admin-chat-scroll');
+      if (el) el.scrollTop = el.scrollHeight;
+    }, 0);
+  }
+}

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.css
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.css
@@ -1,0 +1,57 @@
+.content { padding: 24px; box-sizing: border-box; font-family: 'Montserrat', sans-serif; }
+
+.card {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 14px;
+}
+
+.card-title { font-size: 14px; font-weight: 800; margin-bottom: 12px; }
+
+.toolbar { display: grid; grid-template-columns: 1fr auto; gap: 10px; margin-bottom: 12px; }
+
+.input {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #3a3a3a;
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  padding: 0 12px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  outline: none;
+}
+
+.btn {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #444;
+  background: #2f2f2f;
+  color: #fff;
+  cursor: pointer;
+  padding: 0 16px;
+  font-size: 13px;
+}
+.btn:hover { background: #3a3a3a; border-color: #3a3a3a; }
+
+.hint { color: #cfcfcf; font-size: 12px; }
+
+.list { display: flex; flex-direction: column; gap: 10px; }
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255,255,255,0.04);
+  color: inherit;
+  text-decoration: none;
+}
+.item:hover { background: rgba(255,255,255,0.07); }
+
+.id { font-weight: 800; font-size: 13px; }
+.user { color: #cfcfcf; font-size: 12px; margin-top: 2px; }
+.time { color: #9a9a9a; font-size: 12px; }

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.html
@@ -1,0 +1,26 @@
+<div class="content">
+  <div class="card">
+    <div class="card-title">Chats</div>
+
+    <div class="toolbar">
+      <input class="input" [(ngModel)]="query" placeholder="Search (email / name)..." />
+      <button class="btn" (click)="reload()">Search</button>
+    </div>
+
+    <div *ngIf="loading" class="hint">Loading...</div>
+
+    <div class="list" *ngIf="!loading">
+      <a class="item" *ngFor="let t of threads" [routerLink]="['/admin/chats', t.id]">
+        <div class="left">
+          <div class="id">Thread #{{ t.id }}</div>
+          <div class="user">UserId: {{ t.userId }}</div>
+        </div>
+        <div class="right">
+          <div class="time">{{ t.lastMessageAt ? (t.lastMessageAt | date:'short') : 'No messages' }}</div>
+        </div>
+      </a>
+
+      <div *ngIf="threads.length === 0" class="hint">No chats</div>
+    </div>
+  </div>
+</div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { CHAT_DS } from '../../../api/chat/chat.datasource';
+import { ChatThreadResponse } from '../../../api/chat/models/chat.models';
+
+@Component({
+  selector: 'app-admin-chats',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './admin-chats.html',
+  styleUrl: './admin-chats.css',
+})
+export class AdminChats implements OnInit {
+  private ds = inject(CHAT_DS);
+
+  query = '';
+  threads: ChatThreadResponse[] = [];
+  loading = true;
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  reload(): void {
+    this.loading = true;
+    this.ds.listThreads(this.query, 50).subscribe({
+      next: (res) => {
+        this.threads = res ?? [];
+        this.loading = false;
+      },
+      error: () => (this.loading = false),
+    });
+  }
+}

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-ride-history/driver-ride-history.html
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-ride-history/driver-ride-history.html
@@ -40,7 +40,10 @@
         (click)="openRideDetails(ride.rideId)"
       >
         <span>{{ formatDateOnly(ride.startedAt) }}</span>
-        <span>{{ ride.startAddress }} → {{ ride.endAddress }}</span>
+        <span>
+  {{ truncate(ride.startAddress + ' → ' + ride.endAddress) }}
+</span>
+
         <span>{{ ride.price }} RSD</span>
 
         <span

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-ride-history/driver-ride-history.ts
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-ride-history/driver-ride-history.ts
@@ -116,4 +116,8 @@ export class DriverRideHistoryComponent implements OnInit {
   isCanceled(status: string | undefined, canceled: boolean): boolean {
     return canceled || (status || '').toUpperCase() === 'CANCELED';
   }
+  truncate(text: string, max = 40): string {
+  return text.length > max ? text.slice(0, max) + '…' : text;
+}
+
 }

--- a/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.css
+++ b/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.css
@@ -1,0 +1,79 @@
+.content { padding: 24px; box-sizing: border-box; font-family: 'Montserrat', sans-serif; }
+.grid { display: grid; grid-template-columns: 1fr; }
+
+.card {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 14px;
+}
+
+.card-title { font-size: 14px; font-weight: 800; margin-bottom: 12px; }
+
+.chat {
+  height: 60vh;
+  overflow: auto;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  background: #111;
+  padding: 12px;
+}
+
+.hint { color: #cfcfcf; font-size: 12px; }
+
+.row { display: flex; margin: 10px 0; }
+.row.mine { justify-content: flex-end; }
+
+.bubble {
+  max-width: min(520px, 85%);
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.06);
+}
+
+.row.mine .bubble { background: rgba(47,47,47,0.9); }
+
+.meta { display: flex; gap: 10px; justify-content: space-between; margin-bottom: 6px; }
+.role { font-size: 11px; color: #cfcfcf; font-weight: 700; }
+.time { font-size: 11px; color: #9a9a9a; }
+
+.text { font-size: 13px; line-height: 1.35; white-space: pre-wrap; }
+
+.composer {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+}
+
+.input {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #3a3a3a;
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  padding: 0 12px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  outline: none;
+}
+
+.btn {
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #444;
+  background: #2f2f2f;
+  color: #fff;
+  cursor: pointer;
+  padding: 0 16px;
+  font-size: 13px;
+}
+.btn:hover { background: #3a3a3a; border-color: #3a3a3a; }
+.btn:disabled {
+  background: #1a1a1a;
+  border-color: #1a1a1a;
+  color: #666;
+  cursor: not-allowed;
+}

--- a/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.html
+++ b/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.html
@@ -1,0 +1,31 @@
+<div class="content">
+  <div class="grid">
+    <div class="card">
+      <div class="card-title">Support chat</div>
+
+      <div class="chat" id="chat-scroll">
+        <div *ngIf="loading" class="hint">Loading...</div>
+
+        <div *ngFor="let m of messages" class="row" [class.mine]="isMine(m)">
+          <div class="bubble">
+            <div class="meta">
+              <span class="role">{{ m.senderRole }}</span>
+              <span class="time">{{ m.sentAt | date:'short' }}</span>
+            </div>
+            <div class="text">{{ m.content }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="composer">
+        <input
+          class="input"
+          [(ngModel)]="input"
+          placeholder="Type a message..."
+          (keydown.enter)="send()"
+        />
+        <button class="btn" (click)="send()">Send</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.ts
+++ b/frontend/ddn-frontend/src/app/pages/user/user-chat/user-chat.ts
@@ -1,0 +1,102 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { UserNavbarComponent } from '../../../components/user-navbar/user-navbar';
+import { CHAT_DS } from '../../../api/chat/chat.datasource';
+import { ChatMessageResponse } from '../../../api/chat/models/chat.models';
+
+@Component({
+  selector: 'app-user-chat',
+  standalone: true,
+  imports: [CommonModule, FormsModule, UserNavbarComponent],
+  templateUrl: './user-chat.html',
+  styleUrl: './user-chat.css',
+})
+export class UserChat implements OnInit, OnDestroy {
+  private ds = inject(CHAT_DS);
+
+  messages: ChatMessageResponse[] = [];
+  input = '';
+  loading = true;
+
+  private pollTimer: any = null;
+  private lastId: number | null = null;
+  private sub: Subscription | null = null;
+
+  ngOnInit(): void {
+    // ensure thread exists + initial load
+    this.sub = this.ds.getMyThread().subscribe({
+      next: () => {
+        this.ds.getMyMessages(null, 50).subscribe({
+          next: (msgs) => {
+            this.messages = msgs;
+            this.lastId = msgs.length ? msgs[msgs.length - 1].id : null;
+            this.loading = false;
+            this.startPolling();
+            this.scrollToBottomSoon();
+          },
+          error: () => (this.loading = false),
+        });
+      },
+      error: () => (this.loading = false),
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+    this.sub = null;
+
+    if (this.pollTimer != null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  send(): void {
+    const text = this.input.trim();
+    if (!text) return;
+
+    this.input = '';
+
+    this.ds.sendMyMessage({ content: text }).subscribe({
+      next: (msg) => {
+        this.messages = [...this.messages, msg];
+        this.lastId = msg.id;
+        this.scrollToBottomSoon();
+      },
+      error: () => {
+        // ako želiš: vrati input ili pokaži toast
+      },
+    });
+  }
+
+  private startPolling(): void {
+    if (this.pollTimer != null) return;
+
+    this.pollTimer = setInterval(() => {
+      const after = this.lastId;
+      this.ds.getMyMessages(after, 50).subscribe({
+        next: (newMsgs) => {
+          if (!newMsgs || newMsgs.length === 0) return;
+
+          this.messages = [...this.messages, ...newMsgs];
+          this.lastId = newMsgs[newMsgs.length - 1].id;
+          this.scrollToBottomSoon();
+        },
+      });
+    }, 2500);
+  }
+
+  private scrollToBottomSoon(): void {
+    setTimeout(() => {
+      const el = document.getElementById('chat-scroll');
+      if (el) el.scrollTop = el.scrollHeight;
+    }, 0);
+  }
+
+  isMine(m: ChatMessageResponse): boolean {
+    return m.senderRole !== 'ADMIN';
+  }
+}


### PR DESCRIPTION
Implements a full support chat system: backend controllers, service and JDBC repository, DTOs and DB migration plus frontend UI, routes and HTTP datasource.

Backend: adds ChatService, ChatRepository + JdbcChatRepository, ChatController (user endpoints) and AdminChatController (admin endpoints), DTOs for threads/messages, SQL migration (chat_threads/chat_messages with constraints), and UserLookupRepository.findRoleById. Messages are validated/normalized, role-checked (PASSENGER/DRIVER for user messages, ADMIN for admin), and thread last_message_at is updated. SecurityConfig was tightened to require ADMIN for /api/admin/**.

Frontend: adds CHAT_DS abstraction, ChatHttpDataSource, models, admin (list + details) and user chat pages with polling and message composer, and registers routes/providers. Also minor UI tweaks: navbar CSS unification, driver ride history truncation, and assorted styling for chat pages.