### PR TITLE
Add notifications system and mail queue

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/controller/NotificationController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/NotificationController.java
@@ -1,0 +1,44 @@
+package org.example.backend.controller;
+
+import org.example.backend.dto.response.NotificationResponseDto;
+import org.example.backend.repository.NotificationRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationRepository repo;
+
+    public NotificationController(NotificationRepository repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping("/me")
+    public List<NotificationResponseDto> myNotifications(
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return repo.listForUser(currentUserId(), limit);
+    }
+
+    @GetMapping("/me/unread-count")
+    public long myUnreadCount() {
+        return repo.countUnread(currentUserId());
+    }
+
+    @PostMapping("/me/{id}/read")
+    public void markRead(@PathVariable long id) {
+        repo.markRead(currentUserId(), id);
+    }
+
+    private long currentUserId() {
+        var a = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+        Object p = (a != null) ? a.getPrincipal() : null;
+        if (p instanceof Long l) return l;
+        if (p instanceof Integer i) return i.longValue();
+        if (p instanceof String s) return Long.parseLong(s);
+        throw new IllegalStateException("No authenticated principal userId");
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/dto/response/NotificationResponseDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/NotificationResponseDto.java
@@ -1,0 +1,36 @@
+package org.example.backend.dto.response;
+
+import java.time.OffsetDateTime;
+
+public class NotificationResponseDto {
+    private long id;
+    private String type;
+    private String title;
+    private String message;
+    private String linkUrl;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime readAt;
+
+    public NotificationResponseDto() {}
+
+    public NotificationResponseDto(long id, String type, String title, String message,
+                                   String linkUrl, OffsetDateTime createdAt, OffsetDateTime readAt) {
+        this.id = id; this.type = type; this.title = title; this.message = message;
+        this.linkUrl = linkUrl; this.createdAt = createdAt; this.readAt = readAt;
+    }
+
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public String getLinkUrl() { return linkUrl; }
+    public void setLinkUrl(String linkUrl) { this.linkUrl = linkUrl; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public OffsetDateTime getReadAt() { return readAt; }
+    public void setReadAt(OffsetDateTime readAt) { this.readAt = readAt; }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcNotificationRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcNotificationRepository.java
@@ -1,0 +1,88 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.NotificationResponseDto;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JdbcNotificationRepository implements NotificationRepository {
+
+    private final JdbcClient jdbc;
+
+    public JdbcNotificationRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public List<NotificationResponseDto> listForUser(long userId, int limit) {
+        int lim = Math.max(1, Math.min(limit, 200));
+        return jdbc.sql("""
+            select id, type, title, message, link_url, created_at, read_at
+            from notifications
+            where user_id = :userId
+            order by created_at desc, id desc
+            limit :lim
+        """)
+                .param("userId", userId)
+                .param("lim", lim)
+                .query((rs, rn) -> new NotificationResponseDto(
+                        rs.getLong("id"),
+                        rs.getString("type"),
+                        rs.getString("title"),
+                        rs.getString("message"),
+                        rs.getString("link_url"),
+                        rs.getObject("created_at", java.time.OffsetDateTime.class),
+                        rs.getObject("read_at", java.time.OffsetDateTime.class)
+                ))
+                .list();
+    }
+
+    @Override
+    public long countUnread(long userId) {
+        Long c = jdbc.sql("""
+            select count(1)
+            from notifications
+            where user_id = :userId
+              and read_at is null
+        """)
+                .param("userId", userId)
+                .query(Long.class)
+                .single();
+        return c == null ? 0 : c;
+    }
+
+    @Override
+    public boolean markRead(long userId, long notificationId) {
+        int updated = jdbc.sql("""
+            update notifications
+            set read_at = now()
+            where id = :id
+              and user_id = :userId
+              and read_at is null
+        """)
+                .param("id", notificationId)
+                .param("userId", userId)
+                .update();
+        return updated > 0;
+    }
+
+    @Override
+    public void createForUsers(List<Long> userIds, String type, String title, String message, String linkUrl) {
+        if (userIds == null || userIds.isEmpty()) return;
+
+        for (Long uid : userIds) {
+            jdbc.sql("""
+                insert into notifications(user_id, type, title, message, link_url)
+                values (:userId, :type, :title, :message, :linkUrl)
+            """)
+                    .param("userId", uid)
+                    .param("type", type)
+                    .param("title", title)
+                    .param("message", message)
+                    .param("linkUrl", linkUrl)
+                    .update();
+        }
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/NotificationRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.NotificationResponseDto;
+import java.util.List;
+
+public interface NotificationRepository {
+    List<NotificationResponseDto> listForUser(long userId, int limit);
+    long countUnread(long userId);
+    boolean markRead(long userId, long notificationId);
+
+    void createForUsers(List<Long> userIds, String type, String title, String message, String linkUrl);
+}

--- a/backend/backend/src/main/java/org/example/backend/service/MailQueueService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/MailQueueService.java
@@ -1,0 +1,49 @@
+package org.example.backend.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MailQueueService {
+
+    private final JavaMailSender mailSender;
+
+    public MailQueueService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    /**
+     * Šalje sve mejlove jedan po jedan, ravnomerno raspoređene
+     * tako da svi stignu u zadatom vremenskom prozoru (npr. 10s).
+     * Ne blokira HTTP request.
+     */
+    public void sendBatchWithin(List<SimpleMailMessage> messages, long windowMs) {
+        if (messages == null || messages.isEmpty()) return;
+
+        new Thread(() -> {
+            for (SimpleMailMessage msg : messages) {
+                try {
+                    mailSender.send(msg);
+                    System.out.println("MAIL SENT TO: " + String.join(",", msg.getTo()));
+                } catch (Exception ex) {
+                    System.out.println(
+                            "MAIL FAILED TO: " + String.join(",", msg.getTo()) +
+                                    " | " + ex.getMessage()
+                    );
+                }
+
+                try {
+                    // FIKSAN RAZMAK: 20 SEKUNDI
+                    Thread.sleep(20_000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }).start();
+    }
+
+}

--- a/backend/backend/src/main/java/org/example/backend/service/MailService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/MailService.java
@@ -10,6 +10,9 @@ import org.springframework.stereotype.Service;
 public class MailService {
 
     private final JavaMailSender mailSender;
+    @Value("${app.frontend.base-url:http://localhost:4200}")
+    private String frontendBaseUrl;
+
 
     @Value("${spring.mail.from}")
     private String from;
@@ -31,6 +34,65 @@ public class MailService {
 
         mailSender.send(msg);
     }
+    public SimpleMailMessage buildRideFinishedEmail(
+            String to,
+            Long rideId,
+            String startAddress,
+            String destinationAddress
+    ) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo(to);
+        msg.setSubject("Ride finished");
+        msg.setText(
+                "Your ride has been completed.\n\n" +
+                        "Ride ID: " + rideId + "\n" +
+                        "From: " + startAddress + "\n" +
+                        "To: " + destinationAddress + "\n\n" +
+                        "You can rate the ride within 3 days."
+        );
+        return msg;
+    }
+
+
+    public SimpleMailMessage buildRideAcceptedEmail(
+            String to, Long rideId, String startAddress, String destinationAddress, String trackingLink
+    ) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo(to);
+        msg.setSubject("Ride accepted");
+        msg.setText(
+                "You were added to a ride and a driver has accepted it.\n\n" +
+                        "Ride ID: " + rideId + "\n" +
+                        "From: " + startAddress + "\n" +
+                        "To: " + destinationAddress + "\n\n" +
+                        "Track the ride: " + trackingLink + "\n"
+        );
+        return msg;
+    }
+
+    public void sendRideAcceptedEmail(
+            String to,
+            Long rideId,
+            String startAddress,
+            String destinationAddress,
+            String trackingLink
+    ) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo(to);
+        msg.setSubject("Ride accepted");
+        msg.setText(
+                "You were added to a ride and a driver has accepted it.\n\n" +
+                        "Ride ID: " + rideId + "\n" +
+                        "From: " + startAddress + "\n" +
+                        "To: " + destinationAddress + "\n\n" +
+                        "Track the ride: " + trackingLink + "\n"
+        );
+        mailSender.send(msg);
+    }
+
 
     public void sendRideFinishedEmail(
             String to,

--- a/backend/backend/src/main/java/org/example/backend/service/NotificationService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/NotificationService.java
@@ -1,0 +1,63 @@
+package org.example.backend.service;
+
+import org.example.backend.repository.NotificationRepository;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class NotificationService {
+
+    private final JdbcClient jdbc;
+    private final NotificationRepository repo;
+
+    public NotificationService(JdbcClient jdbc, NotificationRepository repo) {
+        this.jdbc = jdbc;
+        this.repo = repo;
+    }
+
+    public void notifyRideAccepted(long rideId) {
+        List<Long> userIds = registeredPassengerUserIdsForRide(rideId);
+
+        String link = "/user/ride-tracking?rideId=" + rideId;
+
+        repo.createForUsers(
+                userIds,
+                "RIDE_ACCEPTED",
+                "Ride accepted",
+                "You were added to a ride and a driver has accepted it.",
+                link
+        );
+    }
+
+    public void notifyRideFinished(long rideId) {
+        List<Long> userIds = registeredPassengerUserIdsForRide(rideId);
+
+        String link = "/user/ride-tracking?rideId=" + rideId;
+
+        repo.createForUsers(
+                userIds,
+                "RIDE_FINISHED",
+                "Ride finished",
+                "Ride has been successfully completed.",
+                link
+        );
+    }
+
+    private List<Long> registeredPassengerUserIdsForRide(long rideId) {
+        return jdbc.sql("""
+        select distinct u.id
+        from ride_passengers rp
+        join users u
+          on lower(u.email) = lower(rp.email)
+        where rp.ride_id = ?
+          and u.is_active = true
+          and u.blocked = false
+    """)
+                .param(rideId)
+                .query(Long.class)
+                .list();
+    }
+
+}

--- a/backend/backend/src/main/resources/application-mailtrap.properties
+++ b/backend/backend/src/main/resources/application-mailtrap.properties
@@ -1,7 +1,7 @@
 spring.mail.host=sandbox.smtp.mailtrap.io
 spring.mail.port=587
-spring.mail.username=31727ff6c3e396
-spring.mail.password=cde1b6c382c3bf
+spring.mail.username=73a096a4d6de25
+spring.mail.password=aa561caec07903
 
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -23,7 +23,7 @@ app.frontendBaseUrl=http://localhost:4200
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.boot.context.config=DEBUG
 
-
+app.frontend.base-url=http://localhost:4200
 # ===== JWT =====
 app.jwt.secret=${APP_JWT_SECRET:dev-only-change-me-dev-only-change-me-123456}
 app.jwt.ttl-minutes=${APP_JWT_TTL_MINUTES:120}

--- a/backend/backend/src/main/resources/db/migration/V28__notifications.sql
+++ b/backend/backend/src/main/resources/db/migration/V28__notifications.sql
@@ -1,0 +1,19 @@
+create table if not exists notifications (
+                                             id          bigserial primary key,
+                                             user_id     bigint not null references users(id) on delete cascade,
+
+    type        varchar(40) not null,
+    title       varchar(200) not null,
+    message     text not null,
+
+    link_url    text,
+    created_at  timestamptz not null default now(),
+    read_at     timestamptz
+    );
+
+create index if not exists idx_notifications_user_created
+    on notifications(user_id, created_at desc);
+
+create index if not exists idx_notifications_user_unread
+    on notifications(user_id)
+    where read_at is null;

--- a/frontend/ddn-frontend/src/app/api/notifications/models/notification.model.ts
+++ b/frontend/ddn-frontend/src/app/api/notifications/models/notification.model.ts
@@ -1,0 +1,9 @@
+export interface Notification {
+  id: number;
+  type: string;
+  title: string;
+  message: string;
+  linkUrl: string;
+  createdAt: string;
+  readAt: string | null;
+}

--- a/frontend/ddn-frontend/src/app/api/notifications/notification.api.ts
+++ b/frontend/ddn-frontend/src/app/api/notifications/notification.api.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../../app.config';
+import { Notification } from './models/notification.model';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationApi {
+  private http = inject(HttpClient);
+  private baseUrl = inject(API_BASE_URL);
+
+  getMy(limit = 20): Observable<Notification[]> {
+    return this.http.get<Notification[]>(
+      `${this.baseUrl}/notifications/me?limit=${limit}`
+    );
+  }
+
+  getUnreadCount(): Observable<number> {
+    return this.http.get<number>(
+      `${this.baseUrl}/notifications/me/unread-count`
+    );
+  }
+
+  markRead(id: number): Observable<void> {
+    return this.http.post<void>(
+      `${this.baseUrl}/notifications/me/${id}/read`,
+      {}
+    );
+  }
+}

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
@@ -139,3 +139,65 @@ button.logout-btn {
   background: #e53935;
   border-radius: 2px;
 }
+.notif-wrapper {
+  position: relative;
+}
+
+.notif-btn {
+  background: transparent;
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  position: relative;
+}
+
+.badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: #e53935;
+  color: white;
+  border-radius: 50%;
+  font-size: 12px;
+  padding: 2px 6px;
+}
+
+.notif-dropdown {
+  position: absolute;
+  right: 0;
+  top: 40px;
+  width: 320px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 6px;
+  z-index: 1000;
+}
+
+.notif-item {
+  padding: 10px;
+  border-bottom: 1px solid #222;
+  cursor: pointer;
+}
+
+.notif-item.unread {
+  background: rgba(229, 57, 53, 0.12);
+}
+
+.notif-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.title {
+  font-weight: 500;
+}
+
+.msg {
+  font-size: 13px;
+  opacity: 0.85;
+}
+
+.empty {
+  padding: 12px;
+  text-align: center;
+  opacity: 0.6;
+}

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.html
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.html
@@ -25,6 +25,29 @@
   </div>
 
   <div class="nav-right">
+    <div class="notif-wrapper">
+  <button class="notif-btn" (click)="toggle()">
+    🔔
+    <span *ngIf="unreadCount > 0" class="badge">{{ unreadCount }}</span>
+  </button>
+
+  <div class="notif-dropdown" *ngIf="open">
+    <div
+      class="notif-item"
+      *ngFor="let n of notifications"
+      (click)="clickNotification(n)"
+      [class.unread]="!n.readAt"
+    >
+      <div class="title">{{ n.title }}</div>
+      <div class="msg">{{ n.message }}</div>
+    </div>
+
+    <div *ngIf="notifications.length === 0" class="empty">
+      No notifications
+    </div>
+  </div>
+</div>
+
     <a class="nav-link" routerLink="/user/support" routerLinkActive="active">
       Support
     </a>

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.ts
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.ts
@@ -1,17 +1,49 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { AuthStore } from '../../api/auth/auth.store';
+import { NotificationApi } from '../../api/notifications/notification.api';
+import { Notification } from '../../api/notifications/models/notification.model';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-user-navbar',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, CommonModule],
   templateUrl: './user-navbar.html',
   styleUrl: './user-navbar.css',
 })
-export class UserNavbarComponent {
+export class UserNavbarComponent implements OnInit {
   private auth = inject(AuthStore);
   private router = inject(Router);
+  private notificationsApi = inject(NotificationApi);
+
+  notifications: Notification[] = [];
+  unreadCount = 0;
+  open = false;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.notificationsApi.getUnreadCount()
+      .subscribe(c => this.unreadCount = c);
+
+    this.notificationsApi.getMy()
+      .subscribe(n => this.notifications = n);
+  }
+
+  toggle(): void {
+    this.open = !this.open;
+  }
+
+  clickNotification(n: Notification): void {
+    if (!n.readAt) {
+      this.notificationsApi.markRead(n.id).subscribe();
+    }
+    this.open = false;
+    this.router.navigateByUrl(n.linkUrl);
+  }
 
   logout(): void {
     this.auth.clear();


### PR DESCRIPTION
Introduce user notifications end-to-end and a simple mail queuing helper. Backend: add notifications table migration, NotificationRepository + JDBC implementation, NotificationController and NotificationService to create/list/mark notifications; extend MailService with email builders and MailQueueService to send batched emails; update RideOrderService and RideService to enqueue ride-related emails and create notifications; add app.frontend.base-url property and update MailTrap credentials. Frontend: add Notification model + API and show unread badge/dropdown in user-navbar with mark-read behavior.