### PR TITLE
Add admin pages and revamp navbars

### DIFF
--- a/frontend/ddn-frontend/src/app/app.routes.ts
+++ b/frontend/ddn-frontend/src/app/app.routes.ts
@@ -158,6 +158,17 @@ export const routes: Routes = [
     data: { roles: ['ADMIN'] },
     children: [
       {
+  path: 'ride-status',
+  loadComponent: () =>
+    import('./pages/admin/admin-ride-status/admin-ride-status').then(m => m.AdminRideStatus),
+},
+{
+  path: 'pricing',
+  loadComponent: () =>
+    import('./pages/admin/admin-pricing/admin-pricing').then(m => m.AdminPricing),
+},
+
+      {
   path: 'chats',
   loadComponent: () => import('./pages/admin/admin-chats/admin-chats').then(m => m.AdminChats),
   providers: [{ provide: CHAT_DS, useClass: ChatHttpDataSource }],

--- a/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.css
@@ -1,5 +1,5 @@
 .navbar {
-  height: fit-content;
+  height: 60px;
   width: 100%;
   background: linear-gradient(to bottom, #000, #111);
   display: flex;
@@ -14,22 +14,18 @@
 .nav-left,
 .nav-right {
   display: flex;
-  gap: 32px;
+  gap: 18px;
   align-items: center;
+  white-space: nowrap;
 }
 
 .nav-left {
   flex: 1;
+  overflow: hidden; /* ostaje, ali više ne seče dropdown */
 }
 
 .nav-center {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
-.nav-center:empty {
-  pointer-events: none;
+  flex: 0;
 }
 
 .nav-right {
@@ -37,63 +33,45 @@
   justify-content: flex-end;
 }
 
+/* ===== UNIFIED NAV ITEMS ===== */
+.nav-link,
+.nav-link.logout-btn,
+.more-btn {
+  height: 36px;
+  min-height: 36px;
+  line-height: 36px;
+  padding: 0 10px;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: border-box;
+}
+
+/* ===== LINKS ===== */
 .nav-link {
   color: white;
   text-decoration: none;
-  font-size: 20px;
-  font-weight: 100;
+  font-size: 16px;
+  font-weight: 300;
   cursor: pointer;
-
-  padding: 6px 14px;
-  display: inline-flex;
-  align-items: center;
 
   transition: opacity 0.2s ease;
   position: relative;
+
+  background: transparent;
+  border: none;
 }
 
 .nav-link:hover {
-  opacity: 0.8;
+  opacity: 0.85;
 }
 
-.panic-btn {
-  width: 73px;
-  height: 34px;
-  background: #e53935;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.panic-btn img {
-  width: 24px;
-  height: 24px;
-  display: block;
-}
-
-.logout-btn {
-  border: 1px solid #444;
-  border-radius: 6px;
-  font-weight: 300;
-
-  background: rgba(255, 255, 255, 0.08); /* TAMNO default */
-  color: #fff;
-
-  transition: all 0.2s ease;
-}
-
-.logout-btn:hover {
-  background: rgba(255, 255, 255, 0.16); /* SVETLIJE na hover */
-  border-color: #666;
-  opacity: 1;
-}
-
-
+/* ===== ACTIVE LINK ===== */
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 6px;
-  opacity: 1;
 }
 
 .nav-link.active::after {
@@ -106,4 +84,68 @@
   height: 2px;
   background: #e53935;
   border-radius: 2px;
+}
+
+/* ===== LOGOUT BUTTON ===== */
+.logout-btn {
+  border: 1px solid #444;
+  border-radius: 6px;
+  font-weight: 300;
+
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+
+  transition: all 0.2s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: #666;
+}
+
+button.logout-btn {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+/* ===== MORE BUTTON ===== */
+.more-btn {
+  border: 1px solid #444;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.more-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #666;
+  opacity: 1;
+}
+
+/* ===== DROPDOWN (fixed, ne može da ga iseče parent overflow) ===== */
+.more-menu {
+  position: fixed;
+  min-width: 180px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 10px;
+  overflow: hidden;
+  z-index: 99999;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+}
+
+.more-item {
+  display: block;
+  padding: 10px 12px;
+  color: #fff;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 300;
+  border-bottom: 1px solid #222;
+}
+
+.more-item:last-child {
+  border-bottom: none;
+}
+
+.more-item:hover {
+  background: rgba(255, 255, 255, 0.06);
 }

--- a/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.html
+++ b/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.html
@@ -11,14 +11,19 @@
     <a class="nav-link" routerLink="/admin/create-driver" routerLinkActive="active">
       Create Driver
     </a>
+
     <a class="nav-link" routerLink="/admin/chats" routerLinkActive="active">
-  Chats
-</a>
-
-
-    <a class="nav-link" routerLink="/admin/reports" routerLinkActive="active">
-      Reports
+      Chats
     </a>
+
+    <button
+      #moreBtn
+      class="nav-link more-btn"
+      type="button"
+      (click)="toggleMore($event)"
+    >
+      More ▾
+    </button>
   </div>
 
   <div class="nav-center"></div>
@@ -27,9 +32,28 @@
     <a class="nav-link" routerLink="/admin/profile" routerLinkActive="active">
       Profile
     </a>
-  <button class="nav-link logout-btn" type="button" (click)="logout()">
-  Log Out
-  </button>
 
+    <button class="nav-link logout-btn" type="button" (click)="logout()">
+      Log Out
+    </button>
   </div>
 </nav>
+
+<!-- DROPDOWN RENDEROVAN VAN nav-left (fixed), pa ga overflow ne seče -->
+<div
+  class="more-menu"
+  *ngIf="moreOpen"
+  [style.left.px]="moreLeft"
+  [style.top.px]="moreTop"
+  (click)="$event.stopPropagation()"
+>
+  <a class="more-item" routerLink="/admin/ride-status" (click)="closeMore()">
+    Ride Status
+  </a>
+  <a class="more-item" routerLink="/admin/pricing" (click)="closeMore()">
+    Pricing
+  </a>
+  <a class="more-item" routerLink="/admin/reports" (click)="closeMore()">
+    Reports
+  </a>
+</div>

--- a/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.ts
+++ b/frontend/ddn-frontend/src/app/components/admin-navbar/admin-navbar.ts
@@ -1,11 +1,12 @@
-import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, HostListener, ViewChild, inject } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthStore } from '../../api/auth/auth.store';
 
 @Component({
   selector: 'app-admin-navbar',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive],
+  imports: [CommonModule, RouterLink, RouterLinkActive],
   templateUrl: './admin-navbar.html',
   styleUrl: './admin-navbar.css',
 })
@@ -13,8 +14,54 @@ export class AdminNavbar {
   private auth = inject(AuthStore);
   private router = inject(Router);
 
+  moreOpen = false;
+
+  // pozicija dropdown-a (fixed)
+  moreLeft = 0;
+  moreTop = 0;
+
+  @ViewChild('moreBtn', { read: ElementRef })
+  moreBtn?: ElementRef<HTMLElement>;
+
   logout(): void {
     this.auth.clear();
     this.router.navigate(['/login']);
+  }
+
+  toggleMore(ev: MouseEvent): void {
+    ev.stopPropagation();
+
+    this.moreOpen = !this.moreOpen;
+    if (this.moreOpen) {
+      this.repositionMore();
+    }
+  }
+
+  closeMore(): void {
+    this.moreOpen = false;
+  }
+
+  private repositionMore(): void {
+    const el = this.moreBtn?.nativeElement;
+    if (!el) return;
+
+    const r = el.getBoundingClientRect();
+    this.moreLeft = r.left;
+    this.moreTop = r.bottom + 8; // 8px ispod dugmeta
+  }
+
+  @HostListener('window:resize')
+  onResize(): void {
+    if (this.moreOpen) this.repositionMore();
+  }
+
+  @HostListener('window:scroll')
+  onScroll(): void {
+    if (this.moreOpen) this.repositionMore();
+  }
+
+  @HostListener('document:click')
+  onDocumentClick(): void {
+    this.moreOpen = false;
   }
 }

--- a/frontend/ddn-frontend/src/app/components/navbar/navbar.css
+++ b/frontend/ddn-frontend/src/app/components/navbar/navbar.css
@@ -33,24 +33,35 @@
   justify-content: flex-end;
 }
 
-/* ===== LINKS ===== */
+/* ===== UNIFIED NAV ITEMS ===== */
+.nav-link,
+.nav-link.logout-btn {
+  height: 36px;
+  min-height: 36px;
+  line-height: 36px;
+  padding: 0 14px;
 
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: border-box;
+}
+
+/* ===== LINKS ===== */
 .nav-link {
   color: white;
   text-decoration: none;
-  font-size: 20px;
-  font-weight: 100;
+  font-size: 16px;
+  font-weight: 300;
   cursor: pointer;
-
-  padding: 6px 14px;
-  display: inline-flex;
-  align-items: center;
 
   transition: opacity 0.2s ease;
   position: relative;
 
   background: transparent;
   opacity: 1;
+  border: none;
 }
 
 .nav-link:hover {
@@ -58,7 +69,6 @@
 }
 
 /* ===== ACTIVE LINK ===== */
-
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 6px;
@@ -78,10 +88,9 @@
 }
 
 /* ===== PANIC BUTTON ===== */
-
 .panic-btn {
   width: 73px;
-  height: 34px;
+  height: 36px; /* ujednačeno sa nav item */
   background: #e53935;
   border-radius: 8px;
   display: flex;
@@ -96,15 +105,20 @@
 }
 
 /* ===== DRIVER STATUS ===== */
-
 .driver-status {
-  font-size: 14px;
-  padding: 4px 12px;
+  height: 36px;
+  line-height: 36px;
+
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+
   border-radius: 999px;
   border: 1px solid #444;
   background: rgba(255, 255, 255, 0.05);
   color: #ffb300;
   font-weight: 600;
+  font-size: 13px;
 }
 
 .driver-status.available {
@@ -112,27 +126,25 @@
   border-color: #2ecc71;
 }
 
-/* ===== LOGOUT BUTTON (FIXED) ===== */
-
-.nav-link.logout-btn {
+/* ===== LOGOUT BUTTON ===== */
+.logout-btn {
   border: 1px solid #444;
   border-radius: 6px;
   font-weight: 300;
 
-  background: rgba(255, 255, 255, 0.08); /* TAMNO DEFAULT */
+  background: rgba(255, 255, 255, 0.08);
   color: #fff;
 
   opacity: 1;
   transition: all 0.2s ease;
 }
 
-.nav-link.logout-btn:hover {
-  background: rgba(255, 255, 255, 0.16); /* SVETLIJE NA HOVER */
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
   border-color: #666;
   opacity: 1;
 }
 
-/* HARD OVERRIDE ZA <button> */
 button.logout-btn {
   background-color: rgba(255, 255, 255, 0.08);
 }

--- a/frontend/ddn-frontend/src/app/components/public-navbar/public-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/public-navbar/public-navbar.css
@@ -1,42 +1,86 @@
-.public-navbar {
+.navbar {
   height: 60px;
   width: 100%;
   background: linear-gradient(to bottom, #000, #111);
-  border-bottom: 1px solid #2a2a2a;
+  border-bottom: 1px solid #333;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: 0 32px;
   box-sizing: border-box;
   font-family: 'Montserrat', sans-serif;
+  color: #fff;
 }
 
-.left .logo {
-  color: white;
-  font-size: 20px;
-  cursor: pointer;
-}
-
-.right {
+.nav-left,
+.nav-right {
   display: flex;
   gap: 20px;
   align-items: center;
 }
 
-.right a {
-  color: white;
-  text-decoration: none;
-  font-size: 20px;
-  padding: 6px 14px;        
-  border: 1px solid #444;   
-  border-radius: 6px;       
-  transition: all 0.3s ease;
-  cursor: pointer;
+.nav-left {
+  flex: 1;
 }
 
+.nav-center {
+  flex: 1;
+}
 
-.right a:hover {
-  background-color: #4e504e; 
-  color: #fff;               
-  border: 1px solid #4e504e; 
+.nav-right {
+  flex: 1;
+  justify-content: flex-end;
+}
+
+/* logo */
+.logo {
+  color: #fff;
+  font-size: 20px;
+  font-weight: 300;
+  cursor: pointer;
+  padding: 0 14px;
+  height: 36px;
+  line-height: 36px;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* nav items */
+.nav-link {
+  height: 36px;
+  min-height: 36px;
+  line-height: 36px;
+  padding: 0 14px;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: border-box;
+
+  color: #fff;
+  text-decoration: none;
+  font-size: 20px;
+  font-weight: 100;
+
+  border: 1px solid #444;
+  border-radius: 6px;
+
+  background: rgba(255, 255, 255, 0.06);
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #666;
+}
+
+/* optional: CTA malo jači */
+.nav-cta {
+  background: rgba(229, 57, 53, 0.18);
+  border-color: rgba(229, 57, 53, 0.35);
+}
+
+.nav-cta:hover {
+  background: rgba(229, 57, 53, 0.28);
+  border-color: rgba(229, 57, 53, 0.55);
 }

--- a/frontend/ddn-frontend/src/app/components/public-navbar/public-navbar.html
+++ b/frontend/ddn-frontend/src/app/components/public-navbar/public-navbar.html
@@ -1,10 +1,12 @@
-<nav class="public-navbar">
-  <div class="left">
+<nav class="navbar">
+  <div class="nav-left">
     <span class="logo" routerLink="/">Home</span>
   </div>
 
-  <div class="right">
-    <a routerLink="/login" class="signin">Login</a>
-    <a routerLink="/sign-up" class="signup">Sign up</a>
+  <div class="nav-center"></div>
+
+  <div class="nav-right">
+    <a class="nav-link" routerLink="/login">Login</a>
+    <a class="nav-link nav-cta" routerLink="/sign-up">Sign up</a>
   </div>
 </nav>

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.css
@@ -1,5 +1,5 @@
 .navbar {
-  height: fit-content;
+  height: 60px;
   width: 100%;
   background: linear-gradient(to bottom, #000, #111);
   display: flex;
@@ -28,22 +28,19 @@
   justify-content: center;
 }
 
-.nav-center:empty {
-  pointer-events: none;
-}
-
 .nav-right {
   flex: 1;
   justify-content: flex-end;
 }
 
-/* ===== UNIFIED NAV ITEMS (KLJUČNO) ===== */
-
+/* ===== UNIFIED NAV ITEMS ===== */
 .nav-link,
-.nav-link.logout-btn {
-  height: 36px;              /* ISTA VISINA SVUDA */
-  line-height: 36px;         /* ISTA TEKST VERTIKALA */
-  padding: 0 14px;           /* UJEDNAČEN PADDING */
+.nav-link.logout-btn,
+.notif-btn {
+  height: 36px;
+  min-height: 36px;
+  line-height: 36px;
+  padding: 0 14px;
 
   display: inline-flex;
   align-items: center;
@@ -53,12 +50,11 @@
 }
 
 /* ===== LINKS ===== */
-
 .nav-link {
   color: white;
   text-decoration: none;
-  font-size: 20px;
-  font-weight: 100;
+  font-size: 16px;
+  font-weight: 300;
   cursor: pointer;
 
   transition: opacity 0.2s ease;
@@ -66,61 +62,12 @@
 
   background: transparent;
   opacity: 1;
+  border: none;
 }
 
 .nav-link:hover {
   opacity: 0.8;
 }
-
-/* ===== PANIC BUTTON ===== */
-
-.panic-btn {
-  width: 73px;
-  height: 34px;
-  background: #e53935;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.panic-btn img {
-  width: 24px;
-  height: 24px;
-  display: block;
-}
-
-/* ===== LOGOUT BUTTON ===== */
-
-.nav-link.logout-btn {
-  border: 1px solid #444;
-  border-radius: 6px;
-  font-weight: 300;
-
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-
-  opacity: 1;
-  transition: all 0.2s ease;
-}
-
-/* oduzimamo border od visine da bude ISTO */
-.nav-link.logout-btn {
-  height: 36px;
-}
-
-.nav-link.logout-btn:hover {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: #666;
-  opacity: 1;
-}
-
-/* HARD OVERRIDE ZA <button> */
-button.logout-btn {
-  background-color: rgba(255, 255, 255, 0.08);
-}
-
-/* ===== ACTIVE LINK ===== */
 
 .nav-link.active {
   background: rgba(255, 255, 255, 0.08);
@@ -139,38 +86,95 @@ button.logout-btn {
   background: #e53935;
   border-radius: 2px;
 }
+
+/* ===== PANIC BUTTON ===== */
+.panic-btn {
+  width: 73px;
+  height: 36px;
+  background: #e53935;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.panic-btn img {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+/* ===== LOGOUT BUTTON ===== */
+.logout-btn {
+  border: 1px solid #444;
+  border-radius: 6px;
+  font-weight: 300;
+
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+
+  transition: all 0.2s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: #666;
+  opacity: 1;
+}
+
+button.logout-btn {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+/* ===== NOTIFICATIONS ===== */
 .notif-wrapper {
   position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .notif-btn {
   background: transparent;
-  border: none;
-  font-size: 22px;
+  border: 1px solid #444;
+  border-radius: 6px;
+
+  font-size: 18px;
   cursor: pointer;
+
   position: relative;
+  color: #fff;
+
+  padding: 0 12px;
+}
+
+.notif-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: #666;
 }
 
 .badge {
   position: absolute;
-  top: -4px;
-  right: -6px;
+  top: -6px;
+  right: -8px;
   background: #e53935;
   color: white;
-  border-radius: 50%;
-  font-size: 12px;
-  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 7px;
+  border: 1px solid #111;
 }
 
 .notif-dropdown {
   position: absolute;
   right: 0;
-  top: 40px;
+  top: 44px;
   width: 320px;
   background: #111;
   border: 1px solid #333;
-  border-radius: 6px;
+  border-radius: 10px;
   z-index: 1000;
+  overflow: hidden;
 }
 
 .notif-item {
@@ -188,7 +192,8 @@ button.logout-btn {
 }
 
 .title {
-  font-weight: 500;
+  font-weight: 600;
+  font-size: 13px;
 }
 
 .msg {

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.css
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.css
@@ -1,0 +1,5 @@
+@import '../admin-chats/admin-chats.css';
+
+.right .input {
+  width: 180px;
+}

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.html
@@ -1,0 +1,47 @@
+<div class="content">
+  <div class="card">
+    <div class="card-title">Pricing</div>
+
+    <div class="list">
+      <div class="item">
+        <div class="left">
+          <div class="id">Standard</div>
+          <div class="user">Base price for standard vehicle</div>
+        </div>
+        <div class="right">
+          <input class="input" type="number" [(ngModel)]="standardPrice" />
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="left">
+          <div class="id">Luxury</div>
+          <div class="user">Base price for luxury vehicle</div>
+        </div>
+        <div class="right">
+          <input class="input" type="number" [(ngModel)]="luxuryPrice" />
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="left">
+          <div class="id">Van</div>
+          <div class="user">Base price for van</div>
+        </div>
+        <div class="right">
+          <input class="input" type="number" [(ngModel)]="vanPrice" />
+        </div>
+      </div>
+    </div>
+
+    <div style="height: 12px"></div>
+
+    <button class="btn" [disabled]="true">Save</button>
+
+    <div style="height: 10px"></div>
+
+    <div class="hint">
+      Backend not connected yet. Save will be enabled once pricing API is implemented.
+    </div>
+  </div>
+</div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-admin-pricing',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './admin-pricing.html',
+  styleUrl: './admin-pricing.css',
+})
+export class AdminPricing {
+  standardPrice = 0;
+  luxuryPrice = 0;
+  vanPrice = 0;
+
+  saving = false;
+
+  save(): void {
+    // TODO: connect backend later
+  }
+}

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.css
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.css
@@ -1,0 +1,2 @@
+/* koristi isti stil kao AdminChats */
+@import '../admin-chats/admin-chats.css';

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.html
@@ -1,0 +1,20 @@
+<div class="content">
+  <div class="card">
+    <div class="card-title">Ride status</div>
+
+    <div class="toolbar">
+      <input
+        class="input"
+        [(ngModel)]="query"
+        placeholder="Search driver (name / email)..."
+      />
+      <button class="btn" (click)="reload()">Search</button>
+    </div>
+
+    <div *ngIf="loading" class="hint">Loading...</div>
+
+    <div *ngIf="!loading" class="hint">
+      No data yet (backend not connected).
+    </div>
+  </div>
+</div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-admin-ride-status',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './admin-ride-status.html',
+  styleUrl: './admin-ride-status.css',
+})
+export class AdminRideStatus {
+  query = '';
+  loading = false;
+
+  reload(): void {
+    // TODO: connect backend later
+    // for now: keep empty state
+  }
+}


### PR DESCRIPTION
Add two new admin pages (ride-status and pricing) and register their routes under the ADMIN section. Implement placeholder standalone components AdminRideStatus and AdminPricing (Forms/CommonModule imported) with basic templates and styles; both are marked TODO to connect to backend.

Refactor navbars: unify sizing/spacing/typography across admin, user and public navbars, adjust button heights, active-link visuals and logout styling. Enhance AdminNavbar to include a "More" dropdown rendered fixed (so it isn't clipped), with positioning logic, HostListeners for resize/scroll and document click to close. Update templates/CSS accordingly and minor route/template reorganizations.