### PR TITLE
Add admin pricing and ride-status features

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/controller/AdminPricingController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/AdminPricingController.java
@@ -1,0 +1,30 @@
+package org.example.backend.controller;
+
+import jakarta.validation.Valid;
+import org.example.backend.dto.request.AdminPricingUpdateRequestDto;
+import org.example.backend.dto.response.AdminPricingResponseDto;
+import org.example.backend.service.PricingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/pricing")
+public class AdminPricingController {
+
+    private final PricingService service;
+
+    public AdminPricingController(PricingService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public AdminPricingResponseDto get() {
+        return service.get();
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> update(@Valid @RequestBody AdminPricingUpdateRequestDto req) {
+        service.update(req);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/controller/AdminRideStatusController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/AdminRideStatusController.java
@@ -1,0 +1,26 @@
+package org.example.backend.controller;
+
+import org.example.backend.dto.response.AdminRideStatusRowDto;
+import org.example.backend.repository.AdminRideStatusRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/ride-status")
+public class AdminRideStatusController {
+
+    private final AdminRideStatusRepository repo;
+
+    public AdminRideStatusController(AdminRideStatusRepository repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping
+    public List<AdminRideStatusRowDto> list(
+            @RequestParam(defaultValue = "") String q,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return repo.list(q, limit);
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/dto/request/AdminPricingUpdateRequestDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/request/AdminPricingUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package org.example.backend.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record AdminPricingUpdateRequestDto(
+        @NotNull @DecimalMin("0.0") BigDecimal standard,
+        @NotNull @DecimalMin("0.0") BigDecimal luxury,
+        @NotNull @DecimalMin("0.0") BigDecimal van
+) {}

--- a/backend/backend/src/main/java/org/example/backend/dto/response/AdminPricingResponseDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/AdminPricingResponseDto.java
@@ -1,0 +1,9 @@
+package org.example.backend.dto.response;
+
+import java.math.BigDecimal;
+
+public record AdminPricingResponseDto(
+        BigDecimal standard,
+        BigDecimal luxury,
+        BigDecimal van
+) {}

--- a/backend/backend/src/main/java/org/example/backend/dto/response/AdminRideStatusRowDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/AdminRideStatusRowDto.java
@@ -1,0 +1,16 @@
+package org.example.backend.dto.response;
+
+import java.time.OffsetDateTime;
+
+public record AdminRideStatusRowDto(
+        long rideId,
+        long driverId,
+        Long userId,
+        String driverEmail,
+        String driverFirstName,
+        String driverLastName,
+        String status,
+        OffsetDateTime startedAt,
+        double carLat,
+        double carLng
+) {}

--- a/backend/backend/src/main/java/org/example/backend/repository/AdminRideStatusRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/AdminRideStatusRepository.java
@@ -1,0 +1,8 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.AdminRideStatusRowDto;
+import java.util.List;
+
+public interface AdminRideStatusRepository {
+    List<AdminRideStatusRowDto> list(String q, int limit);
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcAdminRideStatusRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcAdminRideStatusRepository.java
@@ -1,0 +1,66 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.response.AdminRideStatusRowDto;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JdbcAdminRideStatusRepository implements AdminRideStatusRepository {
+
+    private final JdbcClient jdbc;
+
+    public JdbcAdminRideStatusRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public List<AdminRideStatusRowDto> list(String q, int limit) {
+        String qq = (q == null) ? "" : q.trim().toLowerCase();
+
+        return jdbc.sql("""
+            select
+              r.id as ride_id,
+              d.id as driver_id,
+              u.id as user_id,
+              u.email as driver_email,
+              u.first_name as driver_first_name,
+              u.last_name as driver_last_name,
+              r.status,
+              r.started_at,
+              v.latitude as car_lat,
+              v.longitude as car_lng
+            from rides r
+            join drivers d on d.id = r.driver_id
+            left join users u on u.id = d.user_id
+            left join vehicles v on v.driver_id = d.id
+            where r.status = 'ACTIVE'
+              and r.canceled = false
+              and r.ended_at is null
+              and (
+                :q = '' or
+                lower(coalesce(u.email,'')) like ('%' || :q || '%') or
+                lower(coalesce(u.first_name,'')) like ('%' || :q || '%') or
+                lower(coalesce(u.last_name,'')) like ('%' || :q || '%')
+              )
+            order by r.started_at desc nulls last, r.id desc
+            limit :limit
+        """)
+                .param("q", qq)
+                .param("limit", Math.max(1, Math.min(limit, 200)))
+                .query((rs, rn) -> new AdminRideStatusRowDto(
+                        rs.getLong("ride_id"),
+                        rs.getLong("driver_id"),
+                        (Long) rs.getObject("user_id", Long.class),
+                        rs.getString("driver_email"),
+                        rs.getString("driver_first_name"),
+                        rs.getString("driver_last_name"),
+                        rs.getString("status"),
+                        rs.getObject("started_at", java.time.OffsetDateTime.class),
+                        rs.getDouble("car_lat"),
+                        rs.getDouble("car_lng")
+                ))
+                .list();
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcPricingRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcPricingRepository.java
@@ -1,0 +1,49 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.request.AdminPricingUpdateRequestDto;
+import org.example.backend.dto.response.AdminPricingResponseDto;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+
+@Repository
+public class JdbcPricingRepository implements PricingRepository {
+
+    private final JdbcClient jdbc;
+
+    public JdbcPricingRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public AdminPricingResponseDto get() {
+        BigDecimal standard = jdbc.sql("select base_price from pricing where vehicle_type='standard'")
+                .query(BigDecimal.class).single();
+        BigDecimal luxury = jdbc.sql("select base_price from pricing where vehicle_type='luxury'")
+                .query(BigDecimal.class).single();
+        BigDecimal van = jdbc.sql("select base_price from pricing where vehicle_type='van'")
+                .query(BigDecimal.class).single();
+
+        return new AdminPricingResponseDto(standard, luxury, van);
+    }
+
+    @Override
+    public void update(AdminPricingUpdateRequestDto req) {
+        jdbc.sql("update pricing set base_price=:p, updated_at=now() where vehicle_type='standard'")
+                .param("p", req.standard()).update();
+        jdbc.sql("update pricing set base_price=:p, updated_at=now() where vehicle_type='luxury'")
+                .param("p", req.luxury()).update();
+        jdbc.sql("update pricing set base_price=:p, updated_at=now() where vehicle_type='van'")
+                .param("p", req.van()).update();
+    }
+
+    @Override
+    public BigDecimal getBasePrice(String vehicleType) {
+        return jdbc.sql("select base_price from pricing where vehicle_type = :t")
+                .param("t", vehicleType)
+                .query(BigDecimal.class)
+                .optional()
+                .orElse(BigDecimal.ZERO);
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/repository/PricingRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/PricingRepository.java
@@ -1,0 +1,13 @@
+package org.example.backend.repository;
+
+import org.example.backend.dto.request.AdminPricingUpdateRequestDto;
+import org.example.backend.dto.response.AdminPricingResponseDto;
+
+import java.math.BigDecimal;
+
+public interface PricingRepository {
+    AdminPricingResponseDto get();
+    void update(AdminPricingUpdateRequestDto req);
+
+    BigDecimal getBasePrice(String vehicleType);
+}

--- a/backend/backend/src/main/java/org/example/backend/service/PricingService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/PricingService.java
@@ -1,0 +1,29 @@
+package org.example.backend.service;
+
+import org.example.backend.dto.request.AdminPricingUpdateRequestDto;
+import org.example.backend.dto.response.AdminPricingResponseDto;
+import org.example.backend.repository.PricingRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+public class PricingService {
+    private final PricingRepository repo;
+
+    public PricingService(PricingRepository repo) {
+        this.repo = repo;
+    }
+
+    public AdminPricingResponseDto get() {
+        return repo.get();
+    }
+
+    public void update(AdminPricingUpdateRequestDto req) {
+        repo.update(req);
+    }
+
+    public BigDecimal basePrice(String vehicleType) {
+        return repo.getBasePrice(vehicleType);
+    }
+}

--- a/backend/backend/src/main/java/org/example/backend/service/RideOrderService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/RideOrderService.java
@@ -35,6 +35,8 @@ public class RideOrderService {
     private final MailService mailService;
     private final NotificationService notificationService;
     private final MailQueueService mailQueueService;
+    private final PricingService pricingService;
+
 
     @Value("${app.frontend.base-url:http://localhost:4200}")
     private String frontendBaseUrl;
@@ -48,7 +50,7 @@ public class RideOrderService {
             UserLookupRepository userLookupRepo,
             MailService mailService,
             NotificationService notificationService,
-            MailQueueService mailQueueService
+            MailQueueService mailQueueService, PricingService pricingService
     ) {
         this.osrmClient = osrmClient;
         this.driverRepo = driverRepo;
@@ -59,6 +61,7 @@ public class RideOrderService {
         this.mailService = mailService;
         this.notificationService = notificationService;
         this.mailQueueService = mailQueueService;
+        this.pricingService = pricingService;
     }
 
     @Transactional
@@ -114,7 +117,7 @@ public class RideOrderService {
         BigDecimal km = BigDecimal.valueOf(metrics.distanceMeters)
                 .divide(BigDecimal.valueOf(1000), 6, RoundingMode.HALF_UP);
 
-        BigDecimal base = basePrice(vehicleType);
+        BigDecimal base = pricingService.basePrice(vehicleType);
         BigDecimal price = base.add(km.multiply(PRICE_PER_KM))
                 .setScale(2, RoundingMode.HALF_UP);
 

--- a/backend/backend/src/main/resources/db/migration/V32__pricing.sql
+++ b/backend/backend/src/main/resources/db/migration/V32__pricing.sql
@@ -1,0 +1,16 @@
+create table if not exists pricing (
+                                       vehicle_type varchar(20) primary key,
+    base_price   numeric(10,2) not null,
+    updated_at   timestamptz not null default now(),
+    constraint pricing_type_chk check (vehicle_type in ('standard','luxury','van')),
+    constraint pricing_base_chk check (base_price >= 0)
+    );
+
+insert into pricing(vehicle_type, base_price)
+select x.vehicle_type, x.base_price
+from (values
+          ('standard', 200.00),
+          ('luxury',   300.00),
+          ('van',      250.00)
+     ) as x(vehicle_type, base_price)
+where not exists (select 1 from pricing p where p.vehicle_type = x.vehicle_type);

--- a/frontend/ddn-frontend/src/app/api/admin/admin-pricing.http.datasource.ts
+++ b/frontend/ddn-frontend/src/app/api/admin/admin-pricing.http.datasource.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../../app.config';
+
+export interface AdminPricingResponseDto {
+  standard: number;
+  luxury: number;
+  van: number;
+}
+
+export interface AdminPricingUpdateRequestDto {
+  standard: number;
+  luxury: number;
+  van: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AdminPricingHttpDataSource {
+  private http = inject(HttpClient);
+  private readonly baseUrl = inject(API_BASE_URL);
+
+  get(): Observable<AdminPricingResponseDto> {
+    return this.http.get<AdminPricingResponseDto>(`${this.baseUrl}/admin/pricing`);
+  }
+
+  update(body: AdminPricingUpdateRequestDto): Observable<void> {
+    return this.http.put<void>(`${this.baseUrl}/admin/pricing`, body);
+  }
+}

--- a/frontend/ddn-frontend/src/app/api/admin/admin-ride-status.http.datasource.ts
+++ b/frontend/ddn-frontend/src/app/api/admin/admin-ride-status.http.datasource.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../../app.config';
+
+export interface AdminRideStatusRowDto {
+  rideId: number;
+  driverId: number;
+  userId: number | null;
+  driverEmail: string | null;
+  driverFirstName: string | null;
+  driverLastName: string | null;
+  status: string;
+  startedAt: string | null;
+  carLat: number;
+  carLng: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AdminRideStatusHttpDataSource {
+  private http = inject(HttpClient);
+  private readonly baseUrl = inject(API_BASE_URL);
+
+  list(q: string, limit = 50): Observable<AdminRideStatusRowDto[]> {
+    let params = new HttpParams().set('limit', String(limit));
+    if (q && q.trim()) params = params.set('q', q.trim());
+    return this.http.get<AdminRideStatusRowDto[]>(`${this.baseUrl}/admin/ride-status`, { params });
+  }
+}

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.html
@@ -36,12 +36,15 @@
 
     <div style="height: 12px"></div>
 
-    <button class="btn" [disabled]="true">Save</button>
+<div *ngIf="loading" class="hint">Loading...</div>
 
-    <div style="height: 10px"></div>
+<button class="btn" (click)="save()" [disabled]="loading || saving">
+  {{ saving ? 'Saving...' : 'Save' }}
+</button>
 
-    <div class="hint">
-      Backend not connected yet. Save will be enabled once pricing API is implemented.
-    </div>
+<div style="height: 10px"></div>
+
+<div *ngIf="error" class="hint">{{ error }}</div>
+
   </div>
 </div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-pricing/admin-pricing.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { AdminPricingHttpDataSource } from '../../../api/admin/admin-pricing.http.datasource';
 
 @Component({
   selector: 'app-admin-pricing',
@@ -9,14 +10,51 @@ import { FormsModule } from '@angular/forms';
   templateUrl: './admin-pricing.html',
   styleUrl: './admin-pricing.css',
 })
-export class AdminPricing {
+export class AdminPricing implements OnInit {
+  private api = inject(AdminPricingHttpDataSource);
+
   standardPrice = 0;
   luxuryPrice = 0;
   vanPrice = 0;
 
+  loading = true;
   saving = false;
+  error = '';
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = '';
+    this.api.get().subscribe({
+      next: (p) => {
+        this.standardPrice = p.standard ?? 0;
+        this.luxuryPrice = p.luxury ?? 0;
+        this.vanPrice = p.van ?? 0;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load pricing';
+        this.loading = false;
+      },
+    });
+  }
 
   save(): void {
-    // TODO: connect backend later
+    this.saving = true;
+    this.error = '';
+    this.api.update({
+      standard: Number(this.standardPrice),
+      luxury: Number(this.luxuryPrice),
+      van: Number(this.vanPrice),
+    }).subscribe({
+      next: () => (this.saving = false),
+      error: () => {
+        this.error = 'Failed to save pricing';
+        this.saving = false;
+      },
+    });
   }
 }

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.css
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.css
@@ -1,2 +1,119 @@
-/* koristi isti stil kao AdminChats */
 @import '../admin-chats/admin-chats.css';
+
+.row { display: flex; flex-direction: column; gap: 10px; }
+
+.item.clickable { cursor: pointer; }
+.item.expanded { background: rgba(255,255,255,0.07); }
+
+.details {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(0,0,0,0.62);
+}
+
+.details-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border: 1px solid #2f2f2f;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #ffb300;
+  box-shadow: 0 0 0 3px rgba(255,179,0,0.12);
+}
+
+.dot.ok {
+  background: #2ecc71;
+  box-shadow: 0 0 0 3px rgba(46,204,113,0.12);
+}
+
+.meta {
+  display: flex;
+  gap: 12px;
+}
+
+.meta-item {
+  padding: 6px 10px;
+  border: 1px solid #2f2f2f;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.03);
+  min-width: 120px;
+}
+
+.meta-item .k { font-size: 11px; color: #9a9a9a; }
+.meta-item .v { font-size: 13px; font-weight: 600; color: #fff; margin-top: 2px; }
+
+.details-body { display: grid; grid-template-columns: 320px 1fr; gap: 14px; }
+
+.mini-map-wrap {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.03);
+}
+
+.mini-map { height: 180px; width: 100%; }
+
+.map-caption {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #cfcfcf;
+  border-top: 1px solid #232323;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  align-content: start;
+}
+
+.kv {
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  background: rgba(255,255,255,0.03);
+  padding: 10px;
+}
+
+.kv .k { font-size: 12px; color: #9a9a9a; margin-bottom: 6px; }
+.kv .v { font-size: 13px; color: #fff; }
+
+.full { grid-column: 1 / -1; }
+
+.cp {
+  display: flex;
+  gap: 10px;
+  padding: 7px 0;
+  border-top: 1px solid #1f1f1f;
+}
+.cp:first-child { border-top: none; }
+
+.cp-ord { font-weight: 800; min-width: 42px; }
+.cp-addr { flex: 1; color: #cfcfcf; }
+.cp-coord { color: #9a9a9a; }
+
+.muted { color: #9a9a9a; }
+
+/* responsive */
+@media (max-width: 980px) {
+  .details-body { grid-template-columns: 1fr; }
+  .meta { flex-wrap: wrap; }
+}

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.html
@@ -3,18 +3,99 @@
     <div class="card-title">Ride status</div>
 
     <div class="toolbar">
-      <input
-        class="input"
-        [(ngModel)]="query"
-        placeholder="Search driver (name / email)..."
-      />
+      <input class="input" [(ngModel)]="query" placeholder="Search driver (name / email)..." />
       <button class="btn" (click)="reload()">Search</button>
     </div>
 
     <div *ngIf="loading" class="hint">Loading...</div>
+    <div *ngIf="!loading && error" class="hint">{{ error }}</div>
 
-    <div *ngIf="!loading" class="hint">
-      No data yet (backend not connected).
+    <div class="list" *ngIf="!loading && !error">
+      <div class="row" *ngFor="let r of rows">
+        <div
+          class="item clickable"
+          (click)="toggleDetails(r)"
+          [class.expanded]="expandedRideId === r.rideId"
+        >
+          <div class="left">
+            <div class="id">Ride #{{ r.rideId }}</div>
+            <div class="user">
+              Driver:
+              {{ (r.driverFirstName || '') + ' ' + (r.driverLastName || '') }}
+              ({{ r.driverEmail || 'no email' }})
+            </div>
+          </div>
+
+          <div class="right">
+            <div class="time">{{ r.startedAt ? (r.startedAt | date:'short') : '—' }}</div>
+            <div class="time">{{ r.carLat.toFixed(5) }}, {{ r.carLng.toFixed(5) }}</div>
+          </div>
+        </div>
+
+        <div class="details" *ngIf="expandedRideId === r.rideId">
+          <div class="details-head">
+            <div class="pill">
+              <span class="dot" [class.ok]="(details?.status || '') === 'ACTIVE'"></span>
+              <span>{{ details?.status || '—' }}</span>
+            </div>
+
+            <div class="meta">
+              <div class="meta-item">
+                <div class="k">ETA</div>
+                <div class="v">{{ details?.etaMinutes != null ? (details?.etaMinutes + ' min') : '—' }}</div>
+              </div>
+              <div class="meta-item">
+                <div class="k">Distance</div>
+                <div class="v">{{ details?.distanceKm != null ? (details?.distanceKm + ' km') : '—' }}</div>
+              </div>
+            </div>
+          </div>
+
+          <div *ngIf="detailsLoading" class="hint">Loading details...</div>
+          <div *ngIf="!detailsLoading && detailsError" class="hint">{{ detailsError }}</div>
+
+          <div class="details-body" *ngIf="!detailsLoading && !detailsError">
+            <div class="mini-map-wrap">
+              <div class="mini-map" [id]="'mini-map-' + r.rideId"></div>
+              <div class="map-caption">
+                Car position:
+                {{ (details?.car?.lat ?? r.carLat).toFixed(5) }},
+                {{ (details?.car?.lng ?? r.carLng).toFixed(5) }}
+              </div>
+            </div>
+
+            <div class="grid">
+              <div class="kv">
+                <div class="k">Pickup</div>
+                <div class="v">
+                  {{ details?.pickup?.lat?.toFixed(5) }}, {{ details?.pickup?.lng?.toFixed(5) }}
+                </div>
+              </div>
+
+              <div class="kv">
+                <div class="k">Destination</div>
+                <div class="v">
+                  {{ details?.destination?.lat?.toFixed(5) }}, {{ details?.destination?.lng?.toFixed(5) }}
+                </div>
+              </div>
+
+              <div class="kv full">
+                <div class="k">Checkpoints</div>
+                <div class="v">
+                  <div *ngIf="(details?.checkpoints?.length || 0) === 0" class="muted">—</div>
+                  <div class="cp" *ngFor="let cp of (details?.checkpoints || [])">
+                    <span class="cp-ord">#{{ cp.order }}</span>
+                    <span class="cp-addr">{{ cp.address }}</span>
+                    <span class="cp-coord">({{ cp.lat.toFixed(5) }}, {{ cp.lng.toFixed(5) }})</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="rows.length === 0" class="hint">No active rides</div>
     </div>
   </div>
 </div>

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.ts
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-ride-status/admin-ride-status.ts
@@ -1,6 +1,30 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+
+import {
+  AdminRideStatusHttpDataSource,
+  AdminRideStatusRowDto
+} from '../../../api/admin/admin-ride-status.http.datasource';
+
+import { API_BASE_URL } from '../../../app.config';
+
+import * as L from 'leaflet';
+
+type LatLngDto = { lat: number; lng: number };
+type RideCheckpointDto = { order: number; address: string; lat: number; lng: number };
+
+type RideTrackingResponseDto = {
+  status?: string;
+  pickup?: LatLngDto;
+  destination?: LatLngDto;
+  car?: LatLngDto;
+  checkpoints?: RideCheckpointDto[];
+  etaMinutes?: number;
+  distanceKm?: number;
+  route?: LatLngDto[];
+};
 
 @Component({
   selector: 'app-admin-ride-status',
@@ -9,12 +33,141 @@ import { FormsModule } from '@angular/forms';
   templateUrl: './admin-ride-status.html',
   styleUrl: './admin-ride-status.css',
 })
-export class AdminRideStatus {
+export class AdminRideStatus implements OnInit {
+  private api = inject(AdminRideStatusHttpDataSource);
+  private http = inject(HttpClient);
+  private baseUrl = inject(API_BASE_URL);
+
   query = '';
-  loading = false;
+  loading = true;
+  rows: AdminRideStatusRowDto[] = [];
+  error = '';
+
+  expandedRideId: number | null = null;
+  detailsLoading = false;
+  detailsError = '';
+  details: RideTrackingResponseDto | null = null;
+
+  private miniMap: L.Map | null = null;
+  private miniMarker: L.Marker | null = null;
+  private miniPolyline: L.Polyline | null = null;
+
+  ngOnInit(): void {
+    this.reload();
+  }
 
   reload(): void {
-    // TODO: connect backend later
-    // for now: keep empty state
+    this.loading = true;
+    this.error = '';
+    this.collapse();
+
+    this.api.list(this.query, 50).subscribe({
+      next: (res) => {
+        this.rows = res ?? [];
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load ride status';
+        this.loading = false;
+      },
+    });
+  }
+
+  toggleDetails(r: AdminRideStatusRowDto): void {
+    if (this.expandedRideId === r.rideId) {
+      this.collapse();
+      return;
+    }
+
+    this.expandedRideId = r.rideId;
+    this.details = null;
+    this.detailsError = '';
+    this.detailsLoading = true;
+
+    this.destroyMiniMap();
+
+    this.http
+      .get<RideTrackingResponseDto>(`${this.baseUrl}/rides/${r.rideId}/tracking`)
+      .subscribe({
+        next: (res) => {
+          this.details = res ?? null;
+          this.detailsLoading = false;
+
+          // nacrtaj mapu nakon rendera DOM-a
+          setTimeout(() => {
+            const fallback = { lat: r.carLat, lng: r.carLng };
+            const pos = this.details?.car ?? fallback;
+            this.renderMiniMap(r.rideId, pos, this.details?.route ?? []);
+          }, 0);
+        },
+        error: () => {
+          this.detailsError = 'Failed to load ride details';
+          this.detailsLoading = false;
+
+          // i dalje nacrtaj mapu sa fallback koordinatama iz liste
+          setTimeout(() => {
+            this.renderMiniMap(r.rideId, { lat: r.carLat, lng: r.carLng }, []);
+          }, 0);
+        },
+      });
+  }
+
+  private collapse(): void {
+    this.expandedRideId = null;
+    this.details = null;
+    this.detailsError = '';
+    this.detailsLoading = false;
+    this.destroyMiniMap();
+  }
+
+  private renderMiniMap(rideId: number, car: LatLngDto, route: LatLngDto[]): void {
+    const elId = `mini-map-${rideId}`;
+    const el = document.getElementById(elId);
+    if (!el) return;
+
+    // reset u slucaju da je ostalo nesto u containeru
+    el.innerHTML = '';
+
+    this.miniMap = L.map(el, {
+      zoomControl: false,
+      attributionControl: false,
+      dragging: true,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      keyboard: false,
+    });
+
+    // tile layer (OSM)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+    }).addTo(this.miniMap);
+
+    // marker (trenutna tacka)
+    this.miniMarker = L.marker([car.lat, car.lng]).addTo(this.miniMap);
+
+    // opcionalno: ako hoces i malu rutu (ako postoji)
+    if (route && route.length >= 2) {
+      const latlngs = route.map(p => [p.lat, p.lng] as [number, number]);
+      this.miniPolyline = L.polyline(latlngs, { weight: 3 }).addTo(this.miniMap);
+
+      const bounds = this.miniPolyline.getBounds();
+      this.miniMap.fitBounds(bounds, { padding: [10, 10] });
+    } else {
+      this.miniMap.setView([car.lat, car.lng], 15);
+    }
+  }
+
+  private destroyMiniMap(): void {
+    try {
+      if (this.miniMap) {
+        this.miniMap.remove();
+      }
+    } catch {
+      // ignore
+    }
+    this.miniMap = null;
+    this.miniMarker = null;
+    this.miniPolyline = null;
   }
 }


### PR DESCRIPTION
Introduce admin pricing and ride-status functionality across backend and frontend. Backend: add AdminPricingController, AdminRideStatusController, PricingService, DTOs, PricingRepository and AdminRideStatusRepository with JDBC implementations, and a V32 SQL migration to create/populate the pricing table; pricing update request fields validated (non-null, >=0). Ride status repo exposes a query to list active rides with driver/vehicle info. Update RideOrderService to use PricingService for base price lookup. Frontend: add HTTP data sources for admin pricing and ride-status, wire admin-pricing UI to load/save prices (with loading/error states), and enhance admin-ride-status page with listing, details fetching, and a mini-map (Leaflet) showing car position and optional route, plus improved styles and error handling.