### PR TITLE
Add user name/email to chat threads

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/dto/response/ChatThreadResponseDto.java
+++ b/backend/backend/src/main/java/org/example/backend/dto/response/ChatThreadResponseDto.java
@@ -5,6 +5,8 @@ import java.time.OffsetDateTime;
 public class ChatThreadResponseDto {
     private long id;
     private long userId;
+    private String userName;
+    private String userEmail;
     private OffsetDateTime lastMessageAt;
 
     public ChatThreadResponseDto() {}
@@ -12,6 +14,25 @@ public class ChatThreadResponseDto {
     public ChatThreadResponseDto(long id, long userId, OffsetDateTime lastMessageAt) {
         this.id = id;
         this.userId = userId;
+        this.userName = null;
+        this.userEmail = null;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+    public ChatThreadResponseDto(long id, long userId, OffsetDateTime lastMessageAt, String userName, String userEmail) {
+        this.id = id;
+        this.userId = userId;
+        this.userName = userName;
+        this.userEmail = userEmail;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+
+    public ChatThreadResponseDto(long id, long userId, String userName, String userEmail, OffsetDateTime lastMessageAt) {
+        this.id = id;
+        this.userId = userId;
+        this.userName = userName;
+        this.userEmail = userEmail;
         this.lastMessageAt = lastMessageAt;
     }
 
@@ -20,6 +41,12 @@ public class ChatThreadResponseDto {
 
     public long getUserId() { return userId; }
     public void setUserId(long userId) { this.userId = userId; }
+
+    public String getUserName() { return userName; }
+    public void setUserName(String userName) { this.userName = userName; }
+
+    public String getUserEmail() { return userEmail; }
+    public void setUserEmail(String userEmail) { this.userEmail = userEmail; }
 
     public OffsetDateTime getLastMessageAt() { return lastMessageAt; }
     public void setLastMessageAt(OffsetDateTime lastMessageAt) { this.lastMessageAt = lastMessageAt; }

--- a/backend/backend/src/main/java/org/example/backend/security/JwtAuthFilter.java
+++ b/backend/backend/src/main/java/org/example/backend/security/JwtAuthFilter.java
@@ -32,7 +32,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String path = request.getServletPath();
 
-        if (path.startsWith("/api/auth/") || path.startsWith("/public/")) {
+        if (
+                path.equals("/api/vehicles/active") ||
+                        path.startsWith("/api/auth/") ||
+                        path.startsWith("/public/")
+        ) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -60,9 +64,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         } catch (Exception e) {
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            SecurityContextHolder.clearContext();
+            filterChain.doFilter(request, response);
             return;
         }
+
 
         filterChain.doFilter(request, response);
     }

--- a/backend/backend/src/main/java/org/example/backend/security/SecurityConfig.java
+++ b/backend/backend/src/main/java/org/example/backend/security/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/registration/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/drivers/activation").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/vehicles/active").permitAll()
                         .requestMatchers("/error").permitAll()
 
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/frontend/ddn-frontend/src/app/api/chat/models/chat.models.ts
+++ b/frontend/ddn-frontend/src/app/api/chat/models/chat.models.ts
@@ -1,8 +1,11 @@
 export type ChatThreadResponse = {
   id: number;
   userId: number;
+  userName: string | null;
+  userEmail: string | null;
   lastMessageAt: string | null;
 };
+
 
 export type ChatMessageResponse = {
   id: number;

--- a/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.html
+++ b/frontend/ddn-frontend/src/app/pages/admin/admin-chats/admin-chats.html
@@ -13,7 +13,11 @@
       <a class="item" *ngFor="let t of threads" [routerLink]="['/admin/chats', t.id]">
         <div class="left">
           <div class="id">Thread #{{ t.id }}</div>
-          <div class="user">UserId: {{ t.userId }}</div>
+          <div class="user">
+  {{ t.userName || ('User #' + t.userId) }}
+  <span *ngIf="t.userEmail">({{ t.userEmail }})</span>
+</div>
+
         </div>
         <div class="right">
           <div class="time">{{ t.lastMessageAt ? (t.lastMessageAt | date:'short') : 'No messages' }}</div>


### PR DESCRIPTION
Return and display user name/email for chat threads. Backend: ChatThreadResponseDto now includes userName and userEmail with new constructors and accessors; JdbcChatRepository SQL selects first_name, last_name and email, constructs a display name (falls back to email) and supports searching by full name. Security: SecurityConfig allows GET /api/vehicles/active and JwtAuthFilter bypasses that path and clears the security context on auth errors before continuing the filter chain. Frontend: chat models and admin chat template updated to show the user's name and email (fallback to user id when name is missing).