### PR TITLE
Add public home map and vehicle markers

### DIFF
--- a/android/TaxiMobile/app/build.gradle.kts
+++ b/android/TaxiMobile/app/build.gradle.kts
@@ -37,6 +37,8 @@ android {
 }
 
 dependencies {
+    implementation("org.osmdroid:osmdroid-android:6.1.18")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     implementation(libs.appcompat)
     implementation(libs.material)
     implementation(libs.activity)

--- a/android/TaxiMobile/app/src/main/AndroidManifest.xml
+++ b/android/TaxiMobile/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
 
     <application
         android:allowBackup="true"
@@ -13,13 +15,18 @@
         android:usesCleartextTraffic="true">
 
         <activity
-            android:name=".feature.auth.ui.LoginActivity"
+            android:name=".feature.publichome.ui.PublicHomeMapActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".feature.auth.ui.LoginActivity"
+            android:exported="false" />
+
 
         <activity
             android:name=".feature.driver.ui.DriverHomeActivity"

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/VehiclesApi.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/VehiclesApi.java
@@ -1,0 +1,20 @@
+package com.example.taximobile.feature.publichome.data;
+
+import com.example.taximobile.feature.publichome.data.dto.response.ActiveVehicleResponseDto;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface VehiclesApi {
+
+    @GET("api/vehicles/active")
+    Call<List<ActiveVehicleResponseDto>> getActiveVehicles(
+            @Query("minLat") Double minLat,
+            @Query("maxLat") Double maxLat,
+            @Query("minLng") Double minLng,
+            @Query("maxLng") Double maxLng
+    );
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/VehiclesRepository.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/VehiclesRepository.java
@@ -1,0 +1,43 @@
+package com.example.taximobile.feature.publichome.data;
+
+import android.content.Context;
+
+import com.example.taximobile.core.network.ApiClient;
+import com.example.taximobile.feature.publichome.data.dto.response.ActiveVehicleResponseDto;
+
+import java.util.Collections;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class VehiclesRepository {
+
+    private final VehiclesApi api;
+
+    public VehiclesRepository(Context ctx) {
+        this.api = ApiClient.get(ctx).create(VehiclesApi.class);
+    }
+
+    public interface ListCb {
+        void onSuccess(List<ActiveVehicleResponseDto> items);
+        void onError(String msg);
+    }
+
+    public void getActiveVehicles(Double minLat, Double maxLat, Double minLng, Double maxLng, ListCb cb) {
+        api.getActiveVehicles(minLat, maxLat, minLng, maxLng).enqueue(new Callback<List<ActiveVehicleResponseDto>>() {
+            @Override
+            public void onResponse(Call<List<ActiveVehicleResponseDto>> call, Response<List<ActiveVehicleResponseDto>> res) {
+                if (!res.isSuccessful()) { cb.onError("HTTP " + res.code()); return; }
+                List<ActiveVehicleResponseDto> body = res.body();
+                cb.onSuccess(body != null ? body : Collections.emptyList());
+            }
+
+            @Override
+            public void onFailure(Call<List<ActiveVehicleResponseDto>> call, Throwable t) {
+                cb.onError(t.getMessage() != null ? t.getMessage() : "Network error");
+            }
+        });
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/dto/response/ActiveVehicleResponseDto.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/data/dto/response/ActiveVehicleResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.taximobile.feature.publichome.data.dto.response;
+
+public class ActiveVehicleResponseDto {
+    private Long id;
+    private double latitude;
+    private double longitude;
+    private boolean busy;
+
+    public ActiveVehicleResponseDto() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public double getLatitude() { return latitude; }
+    public void setLatitude(double latitude) { this.latitude = latitude; }
+
+    public double getLongitude() { return longitude; }
+    public void setLongitude(double longitude) { this.longitude = longitude; }
+
+    public boolean isBusy() { return busy; }
+    public void setBusy(boolean busy) { this.busy = busy; }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/ui/PublicHomeMapActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/publichome/ui/PublicHomeMapActivity.java
@@ -1,0 +1,143 @@
+package com.example.taximobile.feature.publichome.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.auth.ui.LoginActivity;
+import com.example.taximobile.feature.publichome.data.VehiclesRepository;
+import com.example.taximobile.feature.publichome.data.dto.response.ActiveVehicleResponseDto;
+
+import org.osmdroid.config.Configuration;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Marker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublicHomeMapActivity extends AppCompatActivity {
+
+    private MapView map;
+    private VehiclesRepository repo;
+
+    private final List<Marker> markers = new ArrayList<>();
+
+    private final android.os.Handler handler = new android.os.Handler(android.os.Looper.getMainLooper());
+    private final long REFRESH_MS = 2000; // 2s
+    private final Runnable refreshRunnable = new Runnable() {
+        @Override public void run() {
+            loadVehicles();
+            handler.postDelayed(this, REFRESH_MS);
+        }
+    };
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // required by osmdroid
+        Configuration.getInstance().setUserAgentValue(getPackageName());
+
+        setContentView(R.layout.activity_public_home_map);
+
+        map = findViewById(R.id.map);
+        repo = new VehiclesRepository(this);
+
+        findViewById(R.id.btnLogin).setOnClickListener(v ->
+                startActivity(new Intent(this, LoginActivity.class))
+        );
+
+        initMap();
+        loadVehicles();
+    }
+
+    private void initMap() {
+        map.setMultiTouchControls(true);
+
+        // Novi Sad default
+        GeoPoint ns = new GeoPoint(45.2671, 19.8335);
+        map.getController().setZoom(13.5);
+        map.getController().setCenter(ns);
+    }
+
+    private void loadVehicles() {
+        // bez bbox filtera za sada (po specifikaciji: sva aktivna vozila)
+        repo.getActiveVehicles(null, null, null, null, new VehiclesRepository.ListCb() {
+            @Override
+            public void onSuccess(List<ActiveVehicleResponseDto> items) {
+                runOnUiThread(() -> {
+                    renderMarkers(items);
+                    updateStats(items);
+                });
+            }
+
+            @Override
+            public void onError(String msg) {
+                runOnUiThread(() -> {
+                    updateStatsError(msg);
+                });
+            }
+        });
+    }
+
+    private void renderMarkers(List<ActiveVehicleResponseDto> items) {
+        // remove old
+        for (Marker m : markers) {
+            map.getOverlays().remove(m);
+        }
+        markers.clear();
+
+        for (ActiveVehicleResponseDto v : items) {
+            Marker m = new Marker(map);
+            m.setPosition(new GeoPoint(v.getLatitude(), v.getLongitude()));
+            m.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+
+            String status = v.isBusy() ? getString(R.string.vehicle_busy) : getString(R.string.vehicle_free);
+            m.setTitle("Vehicle #" + v.getId());
+            m.setSubDescription(status);
+
+            int iconRes = v.isBusy() ? R.drawable.ic_car_busy : R.drawable.ic_car_free;
+            m.setIcon(androidx.core.content.ContextCompat.getDrawable(this, iconRes));
+
+            markers.add(m);
+            map.getOverlays().add(m);
+        }
+
+
+        map.invalidate();
+    }
+
+    private void updateStats(List<ActiveVehicleResponseDto> items) {
+        int busy = 0;
+        for (ActiveVehicleResponseDto v : items) if (v.isBusy()) busy++;
+
+        int free = items.size() - busy;
+
+        ((android.widget.TextView) findViewById(R.id.tvStats)).setText(
+                getString(R.string.vehicles_stats, free, busy)
+        );
+    }
+
+    private void updateStatsError(String msg) {
+        ((android.widget.TextView) findViewById(R.id.tvStats)).setText(msg);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        map.onResume();
+        handler.post(refreshRunnable);
+
+    }
+
+    @Override
+    protected void onPause() {
+        handler.removeCallbacks(refreshRunnable);
+        map.onPause();
+        super.onPause();
+    }
+}

--- a/android/TaxiMobile/app/src/main/res/drawable/ic_car_busy.xml
+++ b/android/TaxiMobile/app/src/main/res/drawable/ic_car_busy.xml
@@ -1,0 +1,10 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="16dp"
+        android:height="16dp" />
+    <solid android:color="#C62828" />
+    <stroke
+        android:width="2dp"
+        android:color="#FFFFFF" />
+</shape>

--- a/android/TaxiMobile/app/src/main/res/drawable/ic_car_free.xml
+++ b/android/TaxiMobile/app/src/main/res/drawable/ic_car_free.xml
@@ -1,0 +1,10 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="16dp"
+        android:height="16dp" />
+    <solid android:color="#2E7D32" />
+    <stroke
+        android:width="2dp"
+        android:color="#FFFFFF" />
+</shape>

--- a/android/TaxiMobile/app/src/main/res/layout/activity_public_home_map.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/activity_public_home_map.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:title="@string/title_public_home"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <org.osmdroid.views.MapView
+        android:id="@+id/map"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/bottomBar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/tvStats"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/vehicles_loading"
+            android:textSize="14sp" />
+
+        <Button
+            android:id="@+id/btnLogin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_login" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/TaxiMobile/app/src/main/res/values/strings.xml
+++ b/android/TaxiMobile/app/src/main/res/values/strings.xml
@@ -17,6 +17,12 @@
     <string name="home_welcome">Home Screen</string>
 
     <string name="select_date_range">Select date range</string>
+    <string name="title_public_home">Active vehicles</string>
+    <string name="vehicles_loading">Loading vehicles...</string>
+    <string name="vehicles_stats">Free: %1$d | Busy: %2$d</string>
+    <string name="vehicle_free">Free</string>
+    <string name="vehicle_busy">Busy</string>
+
 
 
     <string name="loading_dots">...</string>


### PR DESCRIPTION
Introduce a public home map feature showing active vehicles on an OSMDroid map.

- Adds OSMDroid and OkHttp logging dependencies
- Adds ACCESS_NETWORK_STATE permission
- Makes PublicHomeMapActivity the launcher entry point
- Implements VehiclesApi, VehiclesRepository, and ActiveVehicleResponseDto
- Renders active vehicles on a map with periodic refresh and busy/free indicators
- Adds basic stats, layouts, marker drawables, and string resources
- Moves LoginActivity out of launcher and marks it non-exported

Closes #64 
