### PR TITLE
Add in-app support chat for users and admin

### DIFF
--- a/android/TaxiMobile/app/src/main/AndroidManifest.xml
+++ b/android/TaxiMobile/app/src/main/AndroidManifest.xml
@@ -64,6 +64,20 @@
             android:name=".feature.admin.ui.AdminPlaceholderActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".feature.support.ui.SupportChatActivity"
+            android:exported="false" />
+
+
+        <activity
+            android:name=".feature.admin.ui.AdminSupportThreadsActivity"
+            android:exported="false" />
+
+        <activity
+            android:name=".feature.admin.ui.AdminSupportChatActivity"
+            android:exported="false" />
+
+
     </application>
 
 </manifest>

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/adapter/ChatMessagesAdapter.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/adapter/ChatMessagesAdapter.java
@@ -1,0 +1,70 @@
+package com.example.taximobile.feature.admin.adapter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+
+import java.util.List;
+
+public class ChatMessagesAdapter
+        extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private static final int TYPE_ADMIN = 1;
+    private static final int TYPE_USER = 2;
+
+    private final List<ChatMessageResponseDto> items;
+
+    public ChatMessagesAdapter(List<ChatMessageResponseDto> items) {
+        this.items = items;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return "ADMIN".equals(items.get(position).getSenderRole())
+                ? TYPE_ADMIN : TYPE_USER;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(
+            @NonNull ViewGroup parent, int viewType) {
+
+        int layout = viewType == TYPE_ADMIN
+                ? R.layout.item_chat_admin
+                : R.layout.item_chat_user;
+
+        View v = LayoutInflater.from(parent.getContext())
+                .inflate(layout, parent, false);
+
+        return new VH(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder h, int pos) {
+        ChatMessageResponseDto m = items.get(pos);
+        VH vh = (VH) h;
+        vh.tvContent.setText(m.getContent());
+        vh.tvTime.setText(m.getSentAt().toString());
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class VH extends RecyclerView.ViewHolder {
+        TextView tvContent, tvTime;
+        VH(View v) {
+            super(v);
+            tvContent = v.findViewById(R.id.tvContent);
+            tvTime = v.findViewById(R.id.tvTime);
+        }
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/data/AdminChatApi.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/data/AdminChatApi.java
@@ -1,0 +1,32 @@
+package com.example.taximobile.feature.admin.data;
+
+import com.example.taximobile.feature.support.data.dto.request.ChatSendMessageRequestDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.*;
+
+public interface AdminChatApi {
+
+    @GET("/api/admin/chats")
+    Call<List<ChatThreadResponseDto>> listThreads(
+            @Query("query") String query,
+            @Query("limit") int limit
+    );
+
+    @GET("/api/admin/chats/{threadId}/messages")
+    Call<List<ChatMessageResponseDto>> getThreadMessages(
+            @Path("threadId") long threadId,
+            @Query("afterId") Long afterId,
+            @Query("limit") int limit
+    );
+
+    @POST("/api/admin/chats/{threadId}/messages")
+    Call<ChatMessageResponseDto> sendAdminMessage(
+            @Path("threadId") long threadId,
+            @Body ChatSendMessageRequestDto body
+    );
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/data/AdminChatRepository.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/data/AdminChatRepository.java
@@ -1,0 +1,99 @@
+package com.example.taximobile.feature.admin.data;
+
+import android.content.Context;
+
+import com.example.taximobile.core.network.ApiClient;
+import com.example.taximobile.feature.support.data.dto.request.ChatSendMessageRequestDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminChatRepository {
+
+    private final AdminChatApi api;
+
+    public AdminChatRepository(Context ctx) {
+        api = ApiClient.get(ctx)
+                .create(AdminChatApi.class);
+    }
+
+    /* callbacks */
+    public interface ThreadsCb {
+        void onSuccess(List<ChatThreadResponseDto> list);
+        void onError(String msg);
+    }
+
+    public interface MessagesCb {
+        void onSuccess(List<ChatMessageResponseDto> list);
+        void onError(String msg);
+    }
+
+    public interface SendCb {
+        void onSuccess(ChatMessageResponseDto msg);
+        void onError(String msg);
+    }
+
+    /* API calls */
+
+    public void listThreads(String query, int limit, ThreadsCb cb) {
+        api.listThreads(query, limit).enqueue(new Callback<>() {
+            @Override
+            public void onResponse(Call<List<ChatThreadResponseDto>> call,
+                                   Response<List<ChatThreadResponseDto>> res) {
+                if (res.isSuccessful() && res.body() != null)
+                    cb.onSuccess(res.body());
+                else
+                    cb.onError("Failed to load threads");
+            }
+
+            @Override
+            public void onFailure(Call<List<ChatThreadResponseDto>> call, Throwable t) {
+                cb.onError(t.getMessage());
+            }
+        });
+    }
+
+    public void getThreadMessages(long threadId, Long afterId, int limit, MessagesCb cb) {
+        api.getThreadMessages(threadId, afterId, limit).enqueue(new Callback<>() {
+            @Override
+            public void onResponse(Call<List<ChatMessageResponseDto>> call,
+                                   Response<List<ChatMessageResponseDto>> res) {
+                if (res.isSuccessful() && res.body() != null)
+                    cb.onSuccess(res.body());
+                else
+                    cb.onError("Failed to load messages");
+            }
+
+            @Override
+            public void onFailure(Call<List<ChatMessageResponseDto>> call, Throwable t) {
+                cb.onError(t.getMessage());
+            }
+        });
+    }
+
+    public void sendMessage(long threadId, String content, SendCb cb) {
+        ChatSendMessageRequestDto dto = new ChatSendMessageRequestDto();
+        dto.setContent(content);
+
+        api.sendAdminMessage(threadId, dto).enqueue(new Callback<>() {
+            @Override
+            public void onResponse(Call<ChatMessageResponseDto> call,
+                                   Response<ChatMessageResponseDto> res) {
+                if (res.isSuccessful() && res.body() != null)
+                    cb.onSuccess(res.body());
+                else
+                    cb.onError("Send failed");
+            }
+
+            @Override
+            public void onFailure(Call<ChatMessageResponseDto> call, Throwable t) {
+                cb.onError(t.getMessage());
+            }
+        });
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminBaseActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminBaseActivity.java
@@ -51,9 +51,16 @@ public abstract class AdminBaseActivity extends AppCompatActivity {
                 if (!(this instanceof AdminHomeActivity)) {
                     startActivity(new Intent(this, AdminHomeActivity.class));
                 }
+
+            } else if (id == R.id.nav_chats) {
+                // Admin support live chat threads
+                startActivity(new Intent(this, AdminSupportThreadsActivity.class));
+
             } else if (id == R.id.nav_logout) {
                 LogoutManager.logout(this);
+                drawerLayout.closeDrawers();
                 return true;
+
             } else {
                 Intent i = new Intent(this, AdminPlaceholderActivity.class);
                 i.putExtra(AdminPlaceholderActivity.EXTRA_TITLE, String.valueOf(item.getTitle()));

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminSupportChatActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminSupportChatActivity.java
@@ -1,0 +1,214 @@
+package com.example.taximobile.feature.admin.ui;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.admin.data.AdminChatRepository;
+import com.example.taximobile.feature.support.adapter.ChatMessagesAdapter;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class AdminSupportChatActivity extends AdminBaseActivity {
+
+    public static final String EXTRA_THREAD_ID = "thread_id";
+    public static final String EXTRA_TITLE = "title";
+
+    private RecyclerView recycler;
+    private TextView tvEmpty, tvError;
+    private EditText etMessage;
+    private Button btnSend;
+
+    private final ArrayList<ChatMessageResponseDto> items = new ArrayList<>();
+    private final HashSet<Long> seenIds = new HashSet<>();
+
+    private ChatMessagesAdapter adapter;
+    private AdminChatRepository repo;
+
+    private long threadId;
+    private long lastId = 0L;
+
+    private final android.os.Handler handler =
+            new android.os.Handler(android.os.Looper.getMainLooper());
+
+    private final Runnable pollRunnable = new Runnable() {
+        @Override public void run() {
+            poll();
+            handler.postDelayed(this, 2000);
+        }
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        View v = inflateContent(R.layout.activity_support_chat);
+        toolbar.setTitle(getIntent().getStringExtra(EXTRA_TITLE));
+
+        threadId = getIntent().getLongExtra(EXTRA_THREAD_ID, -1);
+        repo = new AdminChatRepository(this);
+
+        recycler = v.findViewById(R.id.recycler);
+        tvEmpty = v.findViewById(R.id.tvEmpty);
+        tvError = v.findViewById(R.id.tvError);
+        etMessage = v.findViewById(R.id.etMessage);
+        btnSend = v.findViewById(R.id.btnSend);
+
+        LinearLayoutManager lm = new LinearLayoutManager(this);
+        lm.setStackFromEnd(true);
+        recycler.setLayoutManager(lm);
+
+        adapter = new ChatMessagesAdapter(items);
+        recycler.setAdapter(adapter);
+
+        btnSend.setOnClickListener(vv -> send());
+        loadInitial();
+    }
+
+    private void loadInitial() {
+        showError(null);
+
+        repo.getThreadMessages(threadId, null, 50, new AdminChatRepository.MessagesCb() {
+            @Override public void onSuccess(List<ChatMessageResponseDto> list) {
+                runOnUiThread(() -> {
+                    items.clear();
+                    seenIds.clear();
+                    lastId = 0L;
+
+                    if (list != null) {
+                        for (ChatMessageResponseDto m : list) addIfNew(m);
+                    }
+
+                    adapter.notifyDataSetChanged();
+                    updateEmptyState();
+                    scroll();
+                });
+            }
+
+            @Override public void onError(String msg) {
+                runOnUiThread(() -> {
+                    showError(msg);
+                    updateEmptyState();
+                });
+            }
+        });
+    }
+
+    private void poll() {
+        Long after = lastId > 0 ? lastId : null;
+
+        repo.getThreadMessages(threadId, after, 200, new AdminChatRepository.MessagesCb() {
+            @Override public void onSuccess(List<ChatMessageResponseDto> list) {
+                if (list == null || list.isEmpty()) return;
+
+                runOnUiThread(() -> {
+                    int start = items.size();
+                    int added = 0;
+
+                    for (ChatMessageResponseDto m : list) {
+                        if (addIfNew(m)) added++;
+                    }
+
+                    if (added > 0) {
+                        adapter.notifyItemRangeInserted(start, added);
+                        updateEmptyState();
+                        scroll();
+                    }
+                });
+            }
+
+            @Override public void onError(String msg) { }
+        });
+    }
+
+    private void send() {
+        showError(null);
+
+        String text = etMessage.getText() != null ? etMessage.getText().toString().trim() : "";
+        if (TextUtils.isEmpty(text)) return;
+
+        setSending(true);
+
+        repo.sendMessage(threadId, text, new AdminChatRepository.SendCb() {
+            @Override public void onSuccess(ChatMessageResponseDto msg) {
+                runOnUiThread(() -> {
+                    setSending(false);
+                    etMessage.setText("");
+
+                    boolean added = addIfNew(msg);
+                    if (added) {
+                        adapter.notifyItemInserted(items.size() - 1);
+                        updateEmptyState();
+                        scroll();
+                    }
+                });
+            }
+
+            @Override public void onError(String msg) {
+                runOnUiThread(() -> {
+                    setSending(false);
+                    showError(msg);
+                });
+            }
+        });
+    }
+
+    private boolean addIfNew(ChatMessageResponseDto m) {
+        if (m == null) return false;
+        long id = m.getId();
+        if (id <= 0) return false;
+        if (seenIds.contains(id)) return false;
+
+        seenIds.add(id);
+        items.add(m);
+        lastId = Math.max(lastId, id);
+        return true;
+    }
+
+    private void setSending(boolean sending) {
+        btnSend.setEnabled(!sending);
+        btnSend.setText(sending ? "..." : getString(R.string.support_send));
+    }
+
+    private void updateEmptyState() {
+        boolean empty = items.isEmpty();
+        if (tvEmpty != null) tvEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
+        if (recycler != null) recycler.setVisibility(empty ? View.GONE : View.VISIBLE);
+    }
+
+    private void showError(String msg) {
+        if (tvError == null) return;
+        if (msg == null || msg.trim().isEmpty()) {
+            tvError.setVisibility(View.GONE);
+        } else {
+            tvError.setText(msg);
+            tvError.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private void scroll() {
+        if (items.isEmpty()) return;
+        recycler.post(() -> recycler.scrollToPosition(items.size() - 1));
+    }
+
+    @Override protected void onResume() {
+        super.onResume();
+        handler.removeCallbacks(pollRunnable);
+        handler.post(pollRunnable);
+    }
+
+    @Override protected void onPause() {
+        handler.removeCallbacks(pollRunnable);
+        super.onPause();
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminSupportThreadsActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminSupportThreadsActivity.java
@@ -1,0 +1,74 @@
+package com.example.taximobile.feature.admin.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.admin.data.AdminChatRepository;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminSupportThreadsActivity extends AdminBaseActivity {
+
+    private RecyclerView recycler;
+    private TextView tvEmpty, tvError;
+
+    private final List<ChatThreadResponseDto> items = new ArrayList<>();
+    private AdminThreadsAdapter adapter;
+    private AdminChatRepository repo;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        View v = inflateContent(R.layout.activity_admin_threads);
+        toolbar.setTitle("Support");
+
+        recycler = v.findViewById(R.id.recycler);
+        tvEmpty = v.findViewById(R.id.tvEmpty);
+        tvError = v.findViewById(R.id.tvError);
+
+        recycler.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new AdminThreadsAdapter(items, this::openThread);
+
+        recycler.setAdapter(adapter);
+
+        repo = new AdminChatRepository(this);
+        load();
+    }
+
+    private void load() {
+        repo.listThreads(null, 50, new AdminChatRepository.ThreadsCb() {
+            @Override public void onSuccess(List<ChatThreadResponseDto> list) {
+                runOnUiThread(() -> {
+                    items.clear();
+                    items.addAll(list);
+                    adapter.notifyDataSetChanged();
+                    tvEmpty.setVisibility(items.isEmpty() ? View.VISIBLE : View.GONE);
+                });
+            }
+
+            @Override public void onError(String msg) {
+                runOnUiThread(() -> {
+                    tvError.setText(msg);
+                    tvError.setVisibility(View.VISIBLE);
+                });
+            }
+        });
+    }
+
+    private void openThread(ChatThreadResponseDto t) {
+        Intent i = new Intent(this, AdminSupportChatActivity.class);
+        i.putExtra(AdminSupportChatActivity.EXTRA_THREAD_ID, t.getId());
+        i.putExtra(AdminSupportChatActivity.EXTRA_TITLE,
+                t.getUserName() != null ? t.getUserName() : t.getUserEmail());
+        startActivity(i);
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminThreadsAdapter.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/admin/ui/AdminThreadsAdapter.java
@@ -1,0 +1,117 @@
+package com.example.taximobile.feature.admin.ui;
+
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class AdminThreadsAdapter extends RecyclerView.Adapter<AdminThreadsAdapter.VH> {
+
+    public interface OnThreadClickListener {
+        void onClick(ChatThreadResponseDto t);
+    }
+
+    private final List<ChatThreadResponseDto> items;
+    private final OnThreadClickListener onClick;
+
+    public AdminThreadsAdapter(List<ChatThreadResponseDto> items,
+                               OnThreadClickListener onClick) {
+        this.items = items;
+        this.onClick = onClick;
+    }
+
+    @NonNull
+    @Override
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_admin_thread, parent, false);
+        return new VH(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull VH h, int position) {
+        ChatThreadResponseDto t = items.get(position);
+
+        String userName = t.getUserName();
+        String userEmail = t.getUserEmail();
+
+        String title = !isNullOrEmpty(userName) ? userName : userEmail;
+
+        h.tvTitle.setText(title);
+        h.tvSubtitle.setText(userEmail != null ? userEmail : "");
+
+        // lastMessageAt je STRING na Android DTO (Gson)
+        String lm = t.getLastMessageAt();
+        if (!isNullOrEmpty(lm)) {
+            h.tvTime.setText(formatIsoToShort(lm));
+            h.tvTime.setVisibility(View.VISIBLE);
+        } else {
+            h.tvTime.setVisibility(View.GONE);
+        }
+
+        h.itemView.setOnClickListener(v -> {
+            if (onClick != null) onClick.onClick(t);
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    public static class VH extends RecyclerView.ViewHolder {
+        final TextView tvTitle, tvSubtitle, tvTime;
+
+        public VH(View v) {
+            super(v);
+            tvTitle = v.findViewById(R.id.tvTitle);
+            tvSubtitle = v.findViewById(R.id.tvSubtitle);
+            tvTime = v.findViewById(R.id.tvTime);
+        }
+    }
+
+    private static boolean isNullOrEmpty(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    /**
+     * Backend šalje ISO string (Spring OffsetDateTime), npr:
+     * 2026-02-06T18:42:31.123+01:00
+     * Prikaz: dd.MM HH:mm
+     */
+    private static String formatIsoToShort(String iso) {
+        // Ako radi java.time (API 26+ i/ili desugaring), formatiraj normalno
+        try {
+            OffsetDateTime odt = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                odt = OffsetDateTime.parse(iso);
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                return odt.format(DateTimeFormatter.ofPattern("dd.MM HH:mm"));
+            }
+            // Ako iz nekog razloga nema O, fallback ispod
+        } catch (Exception ignored) {
+        }
+
+        // Fallback bez parsiranja (radi svuda):
+        // "2026-02-06T18:42:31..." -> "2026-02-06 18:42"
+        try {
+            String s = iso.replace("T", " ");
+            if (s.length() >= 16) return s.substring(0, 16);
+            return s;
+        } catch (Exception e) {
+            return iso;
+        }
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/driver/ui/DriverBaseActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/driver/ui/DriverBaseActivity.java
@@ -11,6 +11,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 
 import com.example.taximobile.R;
 import com.example.taximobile.core.auth.LogoutManager;
+import com.example.taximobile.feature.support.ui.SupportChatActivity;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.navigation.NavigationView;
 
@@ -50,19 +51,28 @@ public abstract class DriverBaseActivity extends AppCompatActivity {
 
             if (id == R.id.nav_home) {
                 startActivity(new Intent(this, DriverHomeActivity.class));
+
             } else if (id == R.id.nav_history) {
                 startActivity(new Intent(this, DriverRideHistoryActivity.class));
+
             } else if (id == R.id.nav_profile) {
                 startActivity(new Intent(this, DriverProfileActivity.class));
+
+            } else if (id == R.id.nav_support) {
+                // ISTI support chat kao passenger
+                startActivity(new Intent(this, SupportChatActivity.class));
+
             } else if (id == R.id.nav_logout) {
                 LogoutManager.logout(this);
-                return true; // ne zatvaraj drawer ručno, već izlazi
+                drawerLayout.closeDrawers();
+                return true;
             }
 
             drawerLayout.closeDrawers();
             return true;
         });
     }
+
     protected View inflateContent(int layoutResId) {
         View v = getLayoutInflater().inflate(layoutResId, baseContent, false);
         baseContent.addView(v);

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/adapter/ChatMessagesAdapter.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/adapter/ChatMessagesAdapter.java
@@ -1,0 +1,67 @@
+package com.example.taximobile.feature.support.adapter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+
+import java.util.List;
+
+public class ChatMessagesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private static final int VT_ADMIN = 1;
+    private static final int VT_USER  = 2;
+
+    private final List<ChatMessageResponseDto> items;
+
+    public ChatMessagesAdapter(List<ChatMessageResponseDto> items) {
+        this.items = items;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        ChatMessageResponseDto m = items.get(position);
+        String role = m != null ? m.getSenderRole() : null;
+        return "ADMIN".equalsIgnoreCase(role) ? VT_ADMIN : VT_USER;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        int layout = (viewType == VT_ADMIN)
+                ? R.layout.item_chat_message_admin
+                : R.layout.item_chat_message_user;
+
+        View v = LayoutInflater.from(parent.getContext()).inflate(layout, parent, false);
+        return new VH(v);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        ChatMessageResponseDto m = items.get(position);
+        VH vh = (VH) holder;
+
+        vh.tvContent.setText(m != null && m.getContent() != null ? m.getContent() : "");
+        vh.tvTime.setText(m != null && m.getSentAt() != null ? m.getSentAt() : "");
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class VH extends RecyclerView.ViewHolder {
+        TextView tvContent, tvTime;
+        VH(@NonNull View itemView) {
+            super(itemView);
+            tvContent = itemView.findViewById(R.id.tvContent);
+            tvTime = itemView.findViewById(R.id.tvTime);
+        }
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/ChatApi.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/ChatApi.java
@@ -1,0 +1,28 @@
+package com.example.taximobile.feature.support.data;
+
+import com.example.taximobile.feature.support.data.dto.request.ChatSendMessageRequestDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Query;
+
+public interface ChatApi {
+
+    @GET("api/chat/thread/me")
+    Call<ChatThreadResponseDto> getMyThread();
+
+    @GET("api/chat/messages/me")
+    Call<List<ChatMessageResponseDto>> getMyMessages(
+            @Query("afterId") Long afterId,
+            @Query("limit") Integer limit
+    );
+
+    @POST("api/chat/messages/me")
+    Call<ChatMessageResponseDto> sendMyMessage(@Body ChatSendMessageRequestDto req);
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/ChatRepository.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/ChatRepository.java
@@ -1,0 +1,81 @@
+package com.example.taximobile.feature.support.data;
+
+import android.content.Context;
+
+import com.example.taximobile.core.network.ApiClient;
+import com.example.taximobile.feature.support.data.dto.request.ChatSendMessageRequestDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+import com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto;
+
+import java.util.Collections;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class ChatRepository {
+
+    private final ChatApi api;
+
+    public ChatRepository(Context ctx) {
+        this.api = ApiClient.get(ctx).create(ChatApi.class);
+    }
+
+    public interface ThreadCb {
+        void onSuccess(ChatThreadResponseDto thread);
+        void onError(String msg);
+    }
+
+    public interface MessagesCb {
+        void onSuccess(List<ChatMessageResponseDto> items);
+        void onError(String msg);
+    }
+
+    public interface SendCb {
+        void onSuccess(ChatMessageResponseDto msg);
+        void onError(String msg);
+    }
+
+    public void getMyThread(ThreadCb cb) {
+        api.getMyThread().enqueue(new Callback<ChatThreadResponseDto>() {
+            @Override public void onResponse(Call<ChatThreadResponseDto> call, Response<ChatThreadResponseDto> res) {
+                if (!res.isSuccessful()) { cb.onError("HTTP " + res.code()); return; }
+                ChatThreadResponseDto body = res.body();
+                if (body == null) { cb.onError("Empty response"); return; }
+                cb.onSuccess(body);
+            }
+            @Override public void onFailure(Call<ChatThreadResponseDto> call, Throwable t) {
+                cb.onError(t.getMessage() != null ? t.getMessage() : "Network error");
+            }
+        });
+    }
+
+    public void getMyMessages(Long afterId, int limit, MessagesCb cb) {
+        api.getMyMessages(afterId, limit).enqueue(new Callback<List<ChatMessageResponseDto>>() {
+            @Override public void onResponse(Call<List<ChatMessageResponseDto>> call, Response<List<ChatMessageResponseDto>> res) {
+                if (!res.isSuccessful()) { cb.onError("HTTP " + res.code()); return; }
+                List<ChatMessageResponseDto> body = res.body();
+                cb.onSuccess(body != null ? body : Collections.emptyList());
+            }
+            @Override public void onFailure(Call<List<ChatMessageResponseDto>> call, Throwable t) {
+                cb.onError(t.getMessage() != null ? t.getMessage() : "Network error");
+            }
+        });
+    }
+
+    public void sendMyMessage(String content, SendCb cb) {
+        ChatSendMessageRequestDto req = new ChatSendMessageRequestDto(content);
+        api.sendMyMessage(req).enqueue(new Callback<ChatMessageResponseDto>() {
+            @Override public void onResponse(Call<ChatMessageResponseDto> call, Response<ChatMessageResponseDto> res) {
+                if (!res.isSuccessful()) { cb.onError("HTTP " + res.code()); return; }
+                ChatMessageResponseDto body = res.body();
+                if (body == null) { cb.onError("Empty response"); return; }
+                cb.onSuccess(body);
+            }
+            @Override public void onFailure(Call<ChatMessageResponseDto> call, Throwable t) {
+                cb.onError(t.getMessage() != null ? t.getMessage() : "Network error");
+            }
+        });
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/request/ChatSendMessageRequestDto.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/request/ChatSendMessageRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.taximobile.feature.support.data.dto.request;
+
+public class ChatSendMessageRequestDto {
+    private String content;
+
+    public ChatSendMessageRequestDto() {}
+
+    public ChatSendMessageRequestDto(String content) {
+        this.content = content;
+    }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/response/ChatMessageResponseDto.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/response/ChatMessageResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.taximobile.feature.support.data.dto.response;
+
+public class ChatMessageResponseDto {
+    private long id;
+    private String senderRole; // PASSENGER/DRIVER/ADMIN
+    private String content;
+    private String sentAt; // OffsetDateTime kao string (ISO)
+
+    public ChatMessageResponseDto() {}
+
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+
+    public String getSenderRole() { return senderRole; }
+    public void setSenderRole(String senderRole) { this.senderRole = senderRole; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public String getSentAt() { return sentAt; }
+    public void setSentAt(String sentAt) { this.sentAt = sentAt; }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/response/ChatThreadResponseDto.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/data/dto/response/ChatThreadResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.taximobile.feature.support.data.dto.response;
+
+public class ChatThreadResponseDto {
+    private long id;
+    private long userId;
+    private String userName;
+    private String userEmail;
+    private String lastMessageAt; // OffsetDateTime kao string (ISO)
+
+    public ChatThreadResponseDto() {}
+
+    public long getId() { return id; }
+    public void setId(long id) { this.id = id; }
+
+    public long getUserId() { return userId; }
+    public void setUserId(long userId) { this.userId = userId; }
+
+    public String getUserName() { return userName; }
+    public void setUserName(String userName) { this.userName = userName; }
+
+    public String getUserEmail() { return userEmail; }
+    public void setUserEmail(String userEmail) { this.userEmail = userEmail; }
+
+    public String getLastMessageAt() { return lastMessageAt; }
+    public void setLastMessageAt(String lastMessageAt) { this.lastMessageAt = lastMessageAt; }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/ui/SupportChatActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/support/ui/SupportChatActivity.java
@@ -1,0 +1,217 @@
+package com.example.taximobile.feature.support.ui;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.taximobile.R;
+import com.example.taximobile.feature.support.adapter.ChatMessagesAdapter;
+import com.example.taximobile.feature.support.data.ChatRepository;
+import com.example.taximobile.feature.support.data.dto.response.ChatMessageResponseDto;
+import com.example.taximobile.feature.user.ui.UserBaseActivity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class SupportChatActivity extends UserBaseActivity {
+
+    private RecyclerView recycler;
+    private TextView tvEmpty;
+    private TextView tvError;
+    private EditText etMessage;
+    private Button btnSend;
+
+    private ChatRepository repo;
+
+    private final ArrayList<ChatMessageResponseDto> items = new ArrayList<>();
+    private final HashSet<Long> seenIds = new HashSet<>();
+    private ChatMessagesAdapter adapter;
+
+    private final android.os.Handler handler = new android.os.Handler(android.os.Looper.getMainLooper());
+    private final long POLL_MS = 2000;
+    private long lastId = 0L;
+
+    private final Runnable pollRunnable = new Runnable() {
+        @Override public void run() {
+            pollNewMessages();
+            handler.postDelayed(this, POLL_MS);
+        }
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        View v = inflateContent(R.layout.activity_support_chat);
+        toolbar.setTitle(getString(R.string.menu_support));
+
+        repo = new ChatRepository(this);
+
+        recycler = v.findViewById(R.id.recycler);
+        tvEmpty = v.findViewById(R.id.tvEmpty);
+        tvError = v.findViewById(R.id.tvError);
+        etMessage = v.findViewById(R.id.etMessage);
+        btnSend = v.findViewById(R.id.btnSend);
+
+        LinearLayoutManager lm = new LinearLayoutManager(this);
+        lm.setStackFromEnd(true);
+        recycler.setLayoutManager(lm);
+
+        adapter = new ChatMessagesAdapter(items);
+        recycler.setAdapter(adapter);
+
+        btnSend.setOnClickListener(view -> sendMessage());
+
+        repo.getMyThread(new ChatRepository.ThreadCb() {
+            @Override public void onSuccess(com.example.taximobile.feature.support.data.dto.response.ChatThreadResponseDto thread) { }
+            @Override public void onError(String msg) { }
+        });
+
+        loadInitial();
+    }
+
+    private void loadInitial() {
+        showError(null);
+
+        repo.getMyMessages(null, 50, new ChatRepository.MessagesCb() {
+            @Override public void onSuccess(List<ChatMessageResponseDto> list) {
+                runOnUiThread(() -> {
+                    items.clear();
+                    seenIds.clear();
+                    lastId = 0L;
+
+                    if (list != null) {
+                        for (ChatMessageResponseDto m : list) addIfNew(m);
+                    }
+
+                    adapter.notifyDataSetChanged();
+                    updateEmptyState();
+                    scrollToBottom();
+                });
+            }
+
+            @Override public void onError(String msg) {
+                runOnUiThread(() -> {
+                    showError(msg);
+                    updateEmptyState();
+                });
+            }
+        });
+    }
+
+    private void pollNewMessages() {
+        Long after = lastId > 0 ? lastId : null;
+
+        repo.getMyMessages(after, 200, new ChatRepository.MessagesCb() {
+            @Override public void onSuccess(List<ChatMessageResponseDto> list) {
+                if (list == null || list.isEmpty()) return;
+
+                runOnUiThread(() -> {
+                    int start = items.size();
+                    int added = 0;
+
+                    for (ChatMessageResponseDto m : list) {
+                        if (addIfNew(m)) added++;
+                    }
+
+                    if (added > 0) {
+                        adapter.notifyItemRangeInserted(start, added);
+                        updateEmptyState();
+                        scrollToBottom();
+                    }
+                });
+            }
+
+            @Override public void onError(String msg) { }
+        });
+    }
+
+    private void sendMessage() {
+        showError(null);
+
+        String content = etMessage.getText() != null ? etMessage.getText().toString().trim() : "";
+        if (TextUtils.isEmpty(content)) return;
+
+        setSending(true);
+
+        repo.sendMyMessage(content, new ChatRepository.SendCb() {
+            @Override public void onSuccess(ChatMessageResponseDto msg) {
+                runOnUiThread(() -> {
+                    setSending(false);
+                    etMessage.setText("");
+
+                    boolean added = addIfNew(msg);
+                    if (added) {
+                        adapter.notifyItemInserted(items.size() - 1);
+                        updateEmptyState();
+                        scrollToBottom();
+                    }
+                });
+            }
+
+            @Override public void onError(String msg) {
+                runOnUiThread(() -> {
+                    setSending(false);
+                    showError(msg);
+                });
+            }
+        });
+    }
+
+    private boolean addIfNew(ChatMessageResponseDto m) {
+        if (m == null) return false;
+        long id = m.getId();
+        if (id <= 0) return false;
+        if (seenIds.contains(id)) return false;
+
+        seenIds.add(id);
+        items.add(m);
+        lastId = Math.max(lastId, id);
+        return true;
+    }
+
+    private void setSending(boolean sending) {
+        btnSend.setEnabled(!sending);
+        btnSend.setText(sending ? "..." : getString(R.string.support_send));
+    }
+
+    private void updateEmptyState() {
+        boolean empty = items.isEmpty();
+        tvEmpty.setVisibility(empty ? View.VISIBLE : View.GONE);
+        recycler.setVisibility(empty ? View.GONE : View.VISIBLE);
+    }
+
+    private void showError(String msg) {
+        if (msg == null || msg.trim().isEmpty()) {
+            tvError.setVisibility(View.GONE);
+        } else {
+            tvError.setText(msg);
+            tvError.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private void scrollToBottom() {
+        if (items.isEmpty()) return;
+        recycler.post(() -> recycler.scrollToPosition(items.size() - 1));
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        handler.removeCallbacks(pollRunnable);
+        handler.post(pollRunnable);
+    }
+
+    @Override
+    protected void onPause() {
+        handler.removeCallbacks(pollRunnable);
+        super.onPause();
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/ui/UserBaseActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/ui/UserBaseActivity.java
@@ -11,6 +11,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 
 import com.example.taximobile.R;
 import com.example.taximobile.core.auth.LogoutManager;
+import com.example.taximobile.feature.support.ui.SupportChatActivity;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.navigation.NavigationView;
 
@@ -54,7 +55,11 @@ public abstract class UserBaseActivity extends AppCompatActivity {
             } else if (id == R.id.nav_logout) {
                 LogoutManager.logout(this);
                 return true;
-            } else {
+
+            } else if (id == R.id.nav_support) {
+                startActivity(new Intent(this, SupportChatActivity.class));
+            }
+            else{
                 Intent i = new Intent(this, UserPlaceholderActivity.class);
                 i.putExtra(UserPlaceholderActivity.EXTRA_TITLE, String.valueOf(item.getTitle()));
                 startActivity(i);

--- a/android/TaxiMobile/app/src/main/res/drawable/bg_chat_admin.xml
+++ b/android/TaxiMobile/app/src/main/res/drawable/bg_chat_admin.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#E9ECEF"/>
+    <corners android:radius="14dp"/>
+</shape>

--- a/android/TaxiMobile/app/src/main/res/drawable/bg_chat_user.xml
+++ b/android/TaxiMobile/app/src/main/res/drawable/bg_chat_user.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#D1E7DD"/>
+    <corners android:radius="14dp"/>
+</shape>

--- a/android/TaxiMobile/app/src/main/res/layout/activity_admin_threads.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/activity_admin_threads.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Lista thread-ova -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="8dp"/>
+
+    <!-- Empty state -->
+    <TextView
+        android:id="@+id/tvEmpty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No support chats"
+        android:visibility="gone"
+        android:layout_gravity="center"/>
+
+    <!-- Error state -->
+    <TextView
+        android:id="@+id/tvError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/holo_red_dark"
+        android:visibility="gone"
+        android:layout_gravity="center_horizontal|bottom"
+        android:layout_marginBottom="16dp"/>
+</FrameLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/activity_support_chat.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/activity_support_chat.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tvEmpty"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/support_empty"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/recycler"
+        app:layout_constraintBottom_toBottomOf="@id/recycler"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvError"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/support_error"
+        android:textColor="#B00020"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/recycler"
+        app:layout_constraintBottom_toBottomOf="@id/recycler"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <LinearLayout
+        android:id="@+id/bottomBar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/etMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/support_hint"
+            android:minHeight="44dp"/>
+
+        <Button
+            android:id="@+id/btnSend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/support_send"/>
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/item_admin_thread.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/item_admin_thread.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="?attr/selectableItemBackground">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/tvSubtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="13sp"
+        android:textColor="#666666"
+        android:layout_marginTop="2dp"/>
+
+    <TextView
+        android:id="@+id/tvTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="#999999"
+        android:layout_marginTop="4dp"/>
+</LinearLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/item_chat_admin.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/item_chat_admin.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:orientation="vertical"
+        android:background="@drawable/bg_chat_admin"
+        android:padding="10dp">
+
+        <TextView
+            android:id="@+id/tvContent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#CCFFFFFF"
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+</FrameLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/item_chat_message_admin.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/item_chat_message_admin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:orientation="vertical"
+        android:background="@drawable/bg_chat_admin"
+        android:padding="10dp">
+
+        <TextView
+            android:id="@+id/tvContent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#555555"
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+
+</FrameLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/item_chat_message_user.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/item_chat_message_user.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:orientation="vertical"
+        android:background="@drawable/bg_chat_user"
+        android:padding="10dp">
+
+        <TextView
+            android:id="@+id/tvContent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#555555"
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+
+</FrameLayout>

--- a/android/TaxiMobile/app/src/main/res/layout/item_chat_user.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/item_chat_user.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:orientation="vertical"
+        android:background="@drawable/bg_chat_user"
+        android:padding="10dp">
+
+        <TextView
+            android:id="@+id/tvContent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@android:color/black"/>
+
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#555555"
+            android:layout_marginTop="4dp"/>
+    </LinearLayout>
+</FrameLayout>

--- a/android/TaxiMobile/app/src/main/res/values/strings.xml
+++ b/android/TaxiMobile/app/src/main/res/values/strings.xml
@@ -12,6 +12,10 @@
     <string name="menu_support">Support</string>
     <string name="menu_profile">Profile</string>
     <string name="menu_logout">Log out</string>
+    <string name="support_empty">No messages yet. Start the conversation.</string>
+    <string name="support_error">Could not load chat.</string>
+    <string name="support_hint">Type a message…</string>
+    <string name="support_send">Send</string>
 
     <!-- Admin drawer items -->
     <string name="menu_update_requests">Update Requests</string>


### PR DESCRIPTION
Introduce full support chat feature: user-facing SupportChatActivity with ChatRepository and admin-facing AdminSupportThreadsActivity/AdminSupportChatActivity with AdminChatRepository. Add Retrofit APIs (ChatApi, AdminChatApi), DTOs for threads/messages and send-request, adapters for message lists and admin thread list, plus layouts and drawables for chat UI. Implement polling (2s) to fetch new messages, message sending flows and de-duplication logic. Update base activities (UserBaseActivity, DriverBaseActivity, AdminBaseActivity) and AndroidManifest to wire navigation to the support screens; strings.xml updated for labels.
Closes #66 