### PR TITLE
Switch finish ride tests to WebMvcTest; add suites

### DIFF
--- a/backend/backend/pom.xml
+++ b/backend/backend/pom.xml
@@ -124,6 +124,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/backend/backend/run-backend-test-groups.sh
+++ b/backend/backend/run-backend-test-groups.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Student 2 Backend Tests (2.7 - Finish Ride) ==="
+./mvnw -Dtest=Student2FinishRideSuite test
+
+echo
+echo "=== All Backend Tests ==="
+./mvnw -Dtest=AllBackendTestsSuite test

--- a/backend/backend/src/test/java/org/example/backend/controller/DriverControllerFinishWebMvcTest.java
+++ b/backend/backend/src/test/java/org/example/backend/controller/DriverControllerFinishWebMvcTest.java
@@ -1,44 +1,37 @@
 package org.example.backend.controller;
 
-import org.example.backend.service.MailQueueService;
+import org.example.backend.repository.DriverRepository;
+import org.example.backend.security.JwtAuthFilter;
+import org.example.backend.security.JwtService;
+import org.example.backend.security.SecurityConfig;
+import org.example.backend.service.DriverRideService;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.server.ResponseStatusException;
 
-import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = DriverController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
 @ActiveProfiles("test")
-@Sql(
-        scripts = {
-                "classpath:sql/finish/schema.sql",
-                "classpath:sql/finish/reset.sql"
-        },
-        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-)
 class DriverControllerFinishWebMvcTest {
 
     private static final String INVALID_TOKEN = "invalid-token";
@@ -46,141 +39,99 @@ class DriverControllerFinishWebMvcTest {
     private static final long RIDE_ID = 100L;
     private static final long USER_ID = 2L;
     private static final long DRIVER_ID = 10L;
-    private static final long OTHER_DRIVER_ID = 20L;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private JdbcClient jdbc;
+    @MockitoBean
+    private DriverRideService driverRideService;
 
     @MockitoBean
-    private MailQueueService mailQueueService;
+    private DriverRepository driverRepository;
+
+    @MockitoBean
+    private JwtService jwtService;
 
     @Test
     void finishRide_shouldReturn403_whenAuthorizationHeaderIsMissing() throws Exception {
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID))
-                .andExpect(status().isForbidden());
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn403_whenTokenRoleIsPassenger() throws Exception {
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "PASSENGER"))))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn403_whenDriverProfileNotFound() throws Exception {
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn200_whenDriverTokenAndDriverIdAreValid() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, DRIVER_ID, "ACTIVE", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
 
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isOk());
+                .andExpect(MockMvcResultMatchers.status().isOk());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        OffsetDateTime endedAt = jdbc.sql("select ended_at from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(OffsetDateTime.class)
-                .single();
-        Boolean driverAvailable = jdbc.sql("select available from drivers where id = :driverId")
-                .param("driverId", DRIVER_ID)
-                .query(Boolean.class)
-                .single();
-
-        assertEquals("COMPLETED", statusValue);
-        assertNotNull(endedAt);
-        assertEquals(Boolean.TRUE, driverAvailable);
-    }
-
-    @Test
-    void finishRide_shouldCreateNotificationAndQueueEmail_whenRideHasRegisteredPassenger() throws Exception {
-        long passengerUserId = 400L;
-        String passengerEmail = "passenger-driver-endpoint@test.com";
-
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertUser(passengerUserId, passengerEmail);
-        insertRide(RIDE_ID, DRIVER_ID, "ACTIVE", false, null);
-        insertPassenger(RIDE_ID, "Passenger One", passengerEmail);
-
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isOk());
-
-        Long notificationCount = jdbc.sql("""
-                select count(1)
-                from notifications
-                where user_id = :userId
-                  and type = 'RIDE_FINISHED'
-                """)
-                .param("userId", passengerUserId)
-                .query(Long.class)
-                .single();
-        assertEquals(1L, notificationCount);
-
-        ArgumentCaptor<List<SimpleMailMessage>> batchCaptor = batchCaptor();
-        verify(mailQueueService).sendBatchWithin(batchCaptor.capture(), eq(20_000L));
-        assertEquals(1, batchCaptor.getValue().size());
-        assertEquals(passengerEmail, batchCaptor.getValue().get(0).getTo()[0]);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     @Test
     void finishRide_shouldReturn404_whenServiceThrowsNotFound() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, DRIVER_ID, "ACCEPTED", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ride not found or cannot be finished"))
+                .when(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
 
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isNotFound());
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        Boolean driverAvailable = jdbc.sql("select available from drivers where id = :driverId")
-                .param("driverId", DRIVER_ID)
-                .query(Boolean.class)
-                .single();
-        assertEquals("ACCEPTED", statusValue);
-        assertFalse(driverAvailable);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     @Test
     void finishRide_shouldReturn403_whenTokenIsInvalid() throws Exception {
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        doThrow(new RuntimeException("invalid token"))
+                .when(jwtService).parseToken(INVALID_TOKEN);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + INVALID_TOKEN))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verify(jwtService).parseToken(INVALID_TOKEN);
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn404_whenRideBelongsToAnotherDriver() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, OTHER_DRIVER_ID, "ACTIVE", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ride not found or cannot be finished"))
+                .when(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
 
-        mockMvc.perform(put("/api/driver/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/driver/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isNotFound());
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        assertEquals("ACTIVE", statusValue);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     private Authentication auth(long userId, String role) {
@@ -189,70 +140,5 @@ class DriverControllerFinishWebMvcTest {
                 null,
                 java.util.List.of(new SimpleGrantedAuthority("ROLE_" + role))
         );
-    }
-
-    private void insertUser(long userId, String email) {
-        jdbc.sql("""
-                insert into users (id, email, is_active, blocked)
-                values (:id, :email, true, false)
-                """)
-                .param("id", userId)
-                .param("email", email)
-                .update();
-    }
-
-    private void insertPassenger(long rideId, String name, String email) {
-        jdbc.sql("""
-                insert into ride_passengers (ride_id, name, email)
-                values (:rideId, :name, :email)
-                """)
-                .param("rideId", rideId)
-                .param("name", name)
-                .param("email", email)
-                .update();
-    }
-
-    private void insertDriver(long driverId, long userId, boolean available) {
-        jdbc.sql("""
-                insert into drivers (id, user_id, available)
-                values (:id, :userId, :available)
-                """)
-                .param("id", driverId)
-                .param("userId", userId)
-                .param("available", available)
-                .update();
-    }
-
-    private void insertRide(long rideId, long driverId, String status, boolean canceled, OffsetDateTime endedAt) {
-        jdbc.sql("""
-                insert into rides (
-                    id,
-                    driver_id,
-                    status,
-                    canceled,
-                    ended_at,
-                    start_address,
-                    destination_address
-                ) values (
-                    :id,
-                    :driverId,
-                    :status,
-                    :canceled,
-                    :endedAt,
-                    'Start',
-                    'Destination'
-                )
-                """)
-                .param("id", rideId)
-                .param("driverId", driverId)
-                .param("status", status)
-                .param("canceled", canceled)
-                .param("endedAt", endedAt)
-                .update();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static ArgumentCaptor<List<SimpleMailMessage>> batchCaptor() {
-        return (ArgumentCaptor<List<SimpleMailMessage>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(List.class);
     }
 }

--- a/backend/backend/src/test/java/org/example/backend/controller/RideControllerFinishWebMvcTest.java
+++ b/backend/backend/src/test/java/org/example/backend/controller/RideControllerFinishWebMvcTest.java
@@ -1,44 +1,40 @@
 package org.example.backend.controller;
 
-import org.example.backend.service.MailQueueService;
+import org.example.backend.repository.DriverRepository;
+import org.example.backend.security.JwtAuthFilter;
+import org.example.backend.security.JwtService;
+import org.example.backend.security.SecurityConfig;
+import org.example.backend.service.DriverRideService;
+import org.example.backend.service.PassengerRideHistoryService;
+import org.example.backend.service.RideRatingService;
+import org.example.backend.service.RideService;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.web.server.ResponseStatusException;
 
-import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(controllers = RideController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
 @ActiveProfiles("test")
-@Sql(
-        scripts = {
-                "classpath:sql/finish/schema.sql",
-                "classpath:sql/finish/reset.sql"
-        },
-        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-)
 class RideControllerFinishWebMvcTest {
 
     private static final String INVALID_TOKEN = "invalid-token";
@@ -46,141 +42,108 @@ class RideControllerFinishWebMvcTest {
     private static final long RIDE_ID = 100L;
     private static final long USER_ID = 2L;
     private static final long DRIVER_ID = 10L;
-    private static final long OTHER_DRIVER_ID = 20L;
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private JdbcClient jdbc;
+    @MockitoBean
+    private RideService rideService;
 
     @MockitoBean
-    private MailQueueService mailQueueService;
+    private RideRatingService rideRatingService;
+
+    @MockitoBean
+    private PassengerRideHistoryService passengerRideHistoryService;
+
+    @MockitoBean
+    private DriverRideService driverRideService;
+
+    @MockitoBean
+    private DriverRepository driverRepository;
+
+    @MockitoBean
+    private JwtService jwtService;
 
     @Test
     void finishRide_shouldReturn403_whenAuthorizationHeaderIsMissing() throws Exception {
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID))
-                .andExpect(status().isForbidden());
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn403_whenTokenRoleIsPassenger() throws Exception {
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "PASSENGER"))))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn403_whenDriverProfileNotFound() throws Exception {
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn200_whenDriverTokenAndDriverIdAreValid() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, DRIVER_ID, "ACTIVE", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
 
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isOk());
+                .andExpect(MockMvcResultMatchers.status().isOk());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        OffsetDateTime endedAt = jdbc.sql("select ended_at from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(OffsetDateTime.class)
-                .single();
-        Boolean driverAvailable = jdbc.sql("select available from drivers where id = :driverId")
-                .param("driverId", DRIVER_ID)
-                .query(Boolean.class)
-                .single();
-
-        assertEquals("COMPLETED", statusValue);
-        assertNotNull(endedAt);
-        assertEquals(Boolean.TRUE, driverAvailable);
-    }
-
-    @Test
-    void finishRide_shouldCreateNotificationAndQueueEmail_whenRideHasRegisteredPassenger() throws Exception {
-        long passengerUserId = 300L;
-        String passengerEmail = "passenger@test.com";
-
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertUser(passengerUserId, passengerEmail);
-        insertRide(RIDE_ID, DRIVER_ID, "ACTIVE", false, null);
-        insertPassenger(RIDE_ID, "Passenger One", passengerEmail);
-
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isOk());
-
-        Long notificationCount = jdbc.sql("""
-                select count(1)
-                from notifications
-                where user_id = :userId
-                  and type = 'RIDE_FINISHED'
-                """)
-                .param("userId", passengerUserId)
-                .query(Long.class)
-                .single();
-        assertEquals(1L, notificationCount);
-
-        ArgumentCaptor<List<SimpleMailMessage>> batchCaptor = batchCaptor();
-        verify(mailQueueService).sendBatchWithin(batchCaptor.capture(), eq(20_000L));
-        assertEquals(1, batchCaptor.getValue().size());
-        assertEquals(passengerEmail, batchCaptor.getValue().get(0).getTo()[0]);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     @Test
     void finishRide_shouldReturn404_whenServiceThrowsNotFound() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, DRIVER_ID, "ACCEPTED", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ride not found or cannot be finished"))
+                .when(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
 
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isNotFound());
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        Boolean driverAvailable = jdbc.sql("select available from drivers where id = :driverId")
-                .param("driverId", DRIVER_ID)
-                .query(Boolean.class)
-                .single();
-        assertEquals("ACCEPTED", statusValue);
-        assertFalse(driverAvailable);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     @Test
     void finishRide_shouldReturn403_whenTokenIsInvalid() throws Exception {
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        doThrow(new RuntimeException("invalid token"))
+                .when(jwtService).parseToken(INVALID_TOKEN);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + INVALID_TOKEN))
-                .andExpect(status().isForbidden());
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+
+        verify(jwtService).parseToken(INVALID_TOKEN);
+        verifyNoInteractions(driverRideService);
     }
 
     @Test
     void finishRide_shouldReturn404_whenRideBelongsToAnotherDriver() throws Exception {
-        insertUser(USER_ID, "driver@test.com");
-        insertDriver(DRIVER_ID, USER_ID, false);
-        insertRide(RIDE_ID, OTHER_DRIVER_ID, "ACTIVE", false, null);
+        when(driverRepository.findDriverIdByUserId(USER_ID)).thenReturn(Optional.of(DRIVER_ID));
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Ride not found or cannot be finished"))
+                .when(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
 
-        mockMvc.perform(put("/api/rides/{rideId}/finish", RIDE_ID)
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/rides/{rideId}/finish", RIDE_ID)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(auth(USER_ID, "DRIVER"))))
-                .andExpect(status().isNotFound());
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
 
-        String statusValue = jdbc.sql("select status from rides where id = :rideId")
-                .param("rideId", RIDE_ID)
-                .query(String.class)
-                .single();
-        assertEquals("ACTIVE", statusValue);
+        verify(driverRepository).findDriverIdByUserId(USER_ID);
+        verify(driverRideService).finishRide(DRIVER_ID, RIDE_ID);
     }
 
     private Authentication auth(long userId, String role) {
@@ -189,70 +152,5 @@ class RideControllerFinishWebMvcTest {
                 null,
                 java.util.List.of(new SimpleGrantedAuthority("ROLE_" + role))
         );
-    }
-
-    private void insertUser(long userId, String email) {
-        jdbc.sql("""
-                insert into users (id, email, is_active, blocked)
-                values (:id, :email, true, false)
-                """)
-                .param("id", userId)
-                .param("email", email)
-                .update();
-    }
-
-    private void insertPassenger(long rideId, String name, String email) {
-        jdbc.sql("""
-                insert into ride_passengers (ride_id, name, email)
-                values (:rideId, :name, :email)
-                """)
-                .param("rideId", rideId)
-                .param("name", name)
-                .param("email", email)
-                .update();
-    }
-
-    private void insertDriver(long driverId, long userId, boolean available) {
-        jdbc.sql("""
-                insert into drivers (id, user_id, available)
-                values (:id, :userId, :available)
-                """)
-                .param("id", driverId)
-                .param("userId", userId)
-                .param("available", available)
-                .update();
-    }
-
-    private void insertRide(long rideId, long driverId, String status, boolean canceled, OffsetDateTime endedAt) {
-        jdbc.sql("""
-                insert into rides (
-                    id,
-                    driver_id,
-                    status,
-                    canceled,
-                    ended_at,
-                    start_address,
-                    destination_address
-                ) values (
-                    :id,
-                    :driverId,
-                    :status,
-                    :canceled,
-                    :endedAt,
-                    'Start',
-                    'Destination'
-                )
-                """)
-                .param("id", rideId)
-                .param("driverId", driverId)
-                .param("status", status)
-                .param("canceled", canceled)
-                .param("endedAt", endedAt)
-                .update();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static ArgumentCaptor<List<SimpleMailMessage>> batchCaptor() {
-        return (ArgumentCaptor<List<SimpleMailMessage>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(List.class);
     }
 }

--- a/backend/backend/src/test/java/org/example/backend/suite/AllBackendTestsSuite.java
+++ b/backend/backend/src/test/java/org/example/backend/suite/AllBackendTestsSuite.java
@@ -1,0 +1,18 @@
+package org.example.backend.suite;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("All Backend Tests")
+@SelectPackages("org.example.backend")
+@IncludeClassNamePatterns({
+        ".*Test",
+        ".*Tests"
+})
+@ExcludeClassNamePatterns(".*Suite")
+public class AllBackendTestsSuite {
+}

--- a/backend/backend/src/test/java/org/example/backend/suite/Student2FinishRideSuite.java
+++ b/backend/backend/src/test/java/org/example/backend/suite/Student2FinishRideSuite.java
@@ -1,0 +1,22 @@
+package org.example.backend.suite;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("Student 2 Backend Tests (2.7 - Finish Ride)")
+@SelectPackages("org.example.backend")
+@IncludeClassNamePatterns({
+        ".*DriverRideServiceTest",
+        ".*JdbcDriverRepositoryFinishTest",
+        ".*JdbcRideRepositoryFinishTest",
+        ".*JdbcDriverRideRepositoryFinishTest",
+        ".*RideControllerFinishWebMvcTest",
+        ".*DriverControllerFinishWebMvcTest"
+})
+@ExcludeClassNamePatterns(".*Suite")
+public class Student2FinishRideSuite {
+}


### PR DESCRIPTION
Convert RideControllerFinishWebMvcTest and DriverControllerFinishWebMvcTest from full SpringBootTest with JDBC fixtures to focused WebMvcTest slices: import security config, mock JwtService, DriverRepository and DriverRideService (Mockito beans), remove direct DB inserts and mail-queue assertions, and verify service interactions instead. Add junit-platform-suite dependency, create Student2FinishRideSuite and AllBackendTestsSuite to group tests, and add run-backend-test-groups.sh to run the suites via Maven. Overall refactors tests to use mocked services and standard JUnit Platform suites for targeted execution.

Closes #98 