### PR TITLE
Add ride tracking deep links & notifications

### DIFF
--- a/android/TaxiMobile/app/src/main/AndroidManifest.xml
+++ b/android/TaxiMobile/app/src/main/AndroidManifest.xml
@@ -23,6 +23,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="taximobile"
+                    android:host="user"
+                    android:pathPrefix="/ride-tracking" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/auth/ui/LoginActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/auth/ui/LoginActivity.java
@@ -18,9 +18,12 @@ import com.example.taximobile.core.network.TokenStorage;
 import com.example.taximobile.feature.admin.ui.AdminHomeActivity;
 import com.example.taximobile.feature.auth.data.AuthRepository;
 import com.example.taximobile.feature.driver.ui.DriverHomeActivity;
+import com.example.taximobile.feature.user.ui.PassengerActiveRideActivity;
 import com.example.taximobile.feature.user.ui.UserHomeActivity;
 
 public class LoginActivity extends AppCompatActivity {
+
+    public static final String EXTRA_POST_LOGIN_RIDE_ID = "extra_post_login_ride_id";
 
     private EditText etEmail;
     private EditText etPassword;
@@ -114,7 +117,14 @@ public class LoginActivity extends AppCompatActivity {
         }
 
         if ("PASSENGER".equalsIgnoreCase(role) || "USER".equalsIgnoreCase(role)) {
-            startActivity(new Intent(LoginActivity.this, UserHomeActivity.class));
+            long deepLinkRideId = getIntent().getLongExtra(EXTRA_POST_LOGIN_RIDE_ID, -1L);
+            if (deepLinkRideId > 0) {
+                Intent i = new Intent(LoginActivity.this, PassengerActiveRideActivity.class);
+                i.putExtra(PassengerActiveRideActivity.EXTRA_RIDE_ID, deepLinkRideId);
+                startActivity(i);
+            } else {
+                startActivity(new Intent(LoginActivity.this, UserHomeActivity.class));
+            }
             finish();
             return;
         }

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/data/RideActiveApi.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/data/RideActiveApi.java
@@ -7,12 +7,16 @@ import com.example.taximobile.feature.user.data.dto.response.RideTrackingRespons
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 import retrofit2.http.POST;
 
 public interface RideActiveApi {
 
     @GET("api/rides/active/tracking")
     Call<RideTrackingResponseDto> getMyActiveTracking();
+
+    @GET("api/rides/{rideId}/tracking")
+    Call<RideTrackingResponseDto> getRideTrackingById(@Path("rideId") long rideId);
 
     @POST("api/rides/active/reports")
     Call<RideReportResponseDto> reportMyActiveRide(@Body RideReportRequestDto req);

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/data/RideActiveRepository.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/data/RideActiveRepository.java
@@ -25,6 +25,11 @@ public class RideActiveRepository {
         void onError(String msg);
     }
 
+    public interface TrackingByIdCb {
+        void onSuccess(RideTrackingResponseDto dto);
+        void onError(String msg);
+    }
+
     public interface ReportCb {
         void onSuccess(RideReportResponseDto dto);
         void onError(String msg);
@@ -45,6 +50,24 @@ public class RideActiveRepository {
                     return;
                 }
 
+                cb.onError("Failed to load tracking (" + res.code() + ")");
+            }
+
+            @Override
+            public void onFailure(Call<RideTrackingResponseDto> call, Throwable t) {
+                cb.onError(t != null ? t.getMessage() : "Network error");
+            }
+        });
+    }
+
+    public void getTrackingByRideId(long rideId, TrackingByIdCb cb) {
+        api.getRideTrackingById(rideId).enqueue(new Callback<RideTrackingResponseDto>() {
+            @Override
+            public void onResponse(Call<RideTrackingResponseDto> call, Response<RideTrackingResponseDto> res) {
+                if (res.isSuccessful() && res.body() != null) {
+                    cb.onSuccess(res.body());
+                    return;
+                }
                 cb.onError("Failed to load tracking (" + res.code() + ")");
             }
 

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/notifications/NotificationLinkRouter.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/notifications/NotificationLinkRouter.java
@@ -1,0 +1,83 @@
+package com.example.taximobile.feature.user.notifications;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import com.example.taximobile.feature.user.data.dto.response.NotificationResponseDto;
+import com.example.taximobile.feature.user.ui.PassengerActiveRideActivity;
+import com.example.taximobile.feature.user.ui.UserNotificationsActivity;
+
+import java.util.Locale;
+
+public final class NotificationLinkRouter {
+
+    private NotificationLinkRouter() {}
+
+    public static Intent intentForNotification(Context context, NotificationResponseDto notification) {
+        long rideId = extractRideId(notification != null ? notification.getLinkUrl() : null);
+        String type = notification != null ? notification.getType() : null;
+
+        if (rideId > 0) {
+            Intent i = new Intent(context, PassengerActiveRideActivity.class);
+            i.putExtra(PassengerActiveRideActivity.EXTRA_RIDE_ID, rideId);
+
+            if (type != null && !type.trim().isEmpty()) {
+                i.putExtra(PassengerActiveRideActivity.EXTRA_NOTIFICATION_TYPE, type.trim());
+            }
+            if ("RIDE_FINISHED".equalsIgnoreCase(type)) {
+                i.putExtra(PassengerActiveRideActivity.EXTRA_READ_ONLY, true);
+            }
+            return i;
+        }
+
+        return new Intent(context, UserNotificationsActivity.class);
+    }
+
+    public static long extractRideId(String linkUrl) {
+        if (isBlank(linkUrl)) return -1L;
+
+        try {
+            Uri uri = toUri(linkUrl.trim());
+            if (uri == null || !isRideTrackingPath(uri.getPath())) return -1L;
+
+            String rideIdRaw = uri.getQueryParameter("rideId");
+            if (isBlank(rideIdRaw)) return -1L;
+
+            long rideId = Long.parseLong(rideIdRaw.trim());
+            return rideId > 0 ? rideId : -1L;
+        } catch (Exception ignore) {
+            return -1L;
+        }
+    }
+
+    private static Uri toUri(String raw) {
+        if (isBlank(raw)) return null;
+
+        if (raw.contains("://")) {
+            return Uri.parse(raw);
+        }
+        if (raw.startsWith("/")) {
+            return Uri.parse("https://local.app" + raw);
+        }
+
+        return Uri.parse("https://local.app/" + raw);
+    }
+
+    private static boolean isRideTrackingPath(String path) {
+        if (isBlank(path)) return false;
+
+        String p = path.trim().toLowerCase(Locale.US);
+        if (p.endsWith("/")) {
+            p = p.substring(0, p.length() - 1);
+        }
+        return p.equals("/user/ride-tracking")
+                || p.endsWith("/user/ride-tracking")
+                || p.equals("/ride-tracking")
+                || p.endsWith("/ride-tracking");
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/notifications/UserForegroundNotificationPoller.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/notifications/UserForegroundNotificationPoller.java
@@ -1,0 +1,230 @@
+package com.example.taximobile.feature.user.notifications;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import com.example.taximobile.R;
+import com.example.taximobile.core.auth.JwtUtils;
+import com.example.taximobile.core.network.TokenStorage;
+import com.example.taximobile.feature.user.data.NotificationsRepository;
+import com.example.taximobile.feature.user.data.dto.response.NotificationResponseDto;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class UserForegroundNotificationPoller {
+
+    private static final long POLL_INTERVAL_MS = 15_000L;
+    private static final int POLL_LIMIT = 100;
+
+    private static final String CHANNEL_ID = "ride_updates";
+    private static final String PREFS_NAME = "user_notifications";
+    private static final String LAST_SEEN_PREFIX = "notif_last_seen_id_user_";
+
+    private final Activity activity;
+    private final NotificationsRepository repo;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    private boolean running = false;
+
+    private final Runnable pollRunnable = new Runnable() {
+        @Override
+        public void run() {
+            pollOnce();
+        }
+    };
+
+    public UserForegroundNotificationPoller(Activity activity) {
+        this.activity = activity;
+        this.repo = new NotificationsRepository(activity);
+    }
+
+    public void start() {
+        if (running) return;
+        if (!canPostSystemNotifications()) return;
+
+        running = true;
+        createNotificationChannelIfNeeded();
+
+        handler.removeCallbacks(pollRunnable);
+        handler.post(pollRunnable);
+    }
+
+    public void stop() {
+        running = false;
+        handler.removeCallbacks(pollRunnable);
+    }
+
+    private void pollOnce() {
+        if (!running) return;
+
+        if (!canPostSystemNotifications()) {
+            stop();
+            return;
+        }
+
+        repo.list(POLL_LIMIT, new NotificationsRepository.ListCb() {
+            @Override
+            public void onSuccess(List<NotificationResponseDto> items) {
+                handlePollResult(items);
+                scheduleNext();
+            }
+
+            @Override
+            public void onError(String msg) {
+                scheduleNext();
+            }
+        });
+    }
+
+    private void scheduleNext() {
+        if (!running) return;
+        handler.removeCallbacks(pollRunnable);
+        handler.postDelayed(pollRunnable, POLL_INTERVAL_MS);
+    }
+
+    private void handlePollResult(List<NotificationResponseDto> items) {
+        Long userId = currentUserId();
+        if (userId == null || userId <= 0) return;
+
+        SharedPreferences sp = activity.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String key = LAST_SEEN_PREFIX + userId;
+        long lastSeen = sp.getLong(key, Long.MIN_VALUE);
+
+        // First poll after session start: create a baseline.
+        if (lastSeen == Long.MIN_VALUE) {
+            if (items == null || items.isEmpty()) {
+                sp.edit().putLong(key, 0L).apply();
+                return;
+            }
+
+            long baselineMaxId = -1L;
+            for (NotificationResponseDto n : items) {
+                if (n != null && n.getId() > baselineMaxId) {
+                    baselineMaxId = n.getId();
+                }
+            }
+            sp.edit().putLong(key, Math.max(0L, baselineMaxId)).apply();
+            return;
+        }
+
+        if (items == null || items.isEmpty()) return;
+
+        long maxId = -1L;
+        for (NotificationResponseDto n : items) {
+            if (n != null && n.getId() > maxId) {
+                maxId = n.getId();
+            }
+        }
+        if (maxId <= 0) return;
+
+        List<NotificationResponseDto> fresh = new ArrayList<>();
+        for (NotificationResponseDto n : items) {
+            if (n != null && n.getId() > lastSeen) {
+                fresh.add(n);
+            }
+        }
+
+        if (fresh.isEmpty()) {
+            if (maxId > lastSeen) {
+                sp.edit().putLong(key, maxId).apply();
+            }
+            return;
+        }
+
+        fresh.sort(Comparator.comparingLong(NotificationResponseDto::getId));
+        for (NotificationResponseDto n : fresh) {
+            showSystemNotification(n);
+        }
+
+        sp.edit().putLong(key, Math.max(lastSeen, maxId)).apply();
+    }
+
+    private void showSystemNotification(NotificationResponseDto n) {
+        if (n == null || !canPostSystemNotifications()) return;
+
+        String title = nonEmpty(n.getTitle(), activity.getString(R.string.notif_default_title));
+        String message = nonEmpty(n.getMessage(), activity.getString(R.string.notif_default_message));
+
+        android.content.Intent openIntent = NotificationLinkRouter.intentForNotification(activity, n);
+        openIntent.addFlags(
+                android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+                        | android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+                        | android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+        );
+
+        int requestCode = safeNotificationId(n.getId());
+        PendingIntent pi = PendingIntent.getActivity(
+                activity,
+                requestCode,
+                openIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(activity, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_stat_notify)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(pi);
+
+        NotificationManagerCompat.from(activity).notify(requestCode, builder.build());
+    }
+
+    private void createNotificationChannelIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                activity.getString(R.string.notif_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT
+        );
+        channel.setDescription(activity.getString(R.string.notif_channel_description));
+
+        NotificationManager manager = activity.getSystemService(NotificationManager.class);
+        if (manager != null) {
+            manager.createNotificationChannel(channel);
+        }
+    }
+
+    private boolean canPostSystemNotifications() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && ActivityCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED) {
+            return false;
+        }
+        return NotificationManagerCompat.from(activity).areNotificationsEnabled();
+    }
+
+    private Long currentUserId() {
+        String token = new TokenStorage(activity.getApplicationContext()).getToken();
+        if (token == null || token.trim().isEmpty()) return null;
+        return JwtUtils.getUserIdFromSub(token);
+    }
+
+    private static int safeNotificationId(long notificationId) {
+        long base = Math.abs(notificationId % 1_000_000L);
+        return (int) (30_000L + base);
+    }
+
+    private static String nonEmpty(String value, String fallback) {
+        if (value == null || value.trim().isEmpty()) return fallback;
+        return value.trim();
+    }
+}

--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/ui/UserNotificationsActivity.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/user/ui/UserNotificationsActivity.java
@@ -1,5 +1,6 @@
 package com.example.taximobile.feature.user.ui;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -12,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.taximobile.R;
 import com.example.taximobile.feature.user.data.NotificationsRepository;
 import com.example.taximobile.feature.user.data.dto.response.NotificationResponseDto;
+import com.example.taximobile.feature.user.notifications.NotificationLinkRouter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +35,7 @@ public class UserNotificationsActivity extends UserBaseActivity
 
         View v = inflateContent(R.layout.activity_user_notifications);
 
-        toolbar.setTitle("Notifications");
+        toolbar.setTitle(getString(R.string.title_notifications));
 
         repo = new NotificationsRepository(this);
 
@@ -83,8 +85,12 @@ public class UserNotificationsActivity extends UserBaseActivity
             });
         }
 
-        if (n.getLinkUrl() != null && !n.getLinkUrl().isBlank()) {
-            Toast.makeText(this, n.getLinkUrl(), Toast.LENGTH_SHORT).show();
+        Intent target = NotificationLinkRouter.intentForNotification(this, n);
+        if (target.getComponent() != null
+                && UserNotificationsActivity.class.getName().equals(target.getComponent().getClassName())) {
+            return;
         }
+        target.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        startActivity(target);
     }
 }

--- a/android/TaxiMobile/app/src/main/res/drawable/ic_stat_notify.xml
+++ b/android/TaxiMobile/app/src/main/res/drawable/ic_stat_notify.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 1.99,-0.9 1.99,-2h-3.98c0,1.1 0.89,2 1.99,2zM18,16v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.64,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/android/TaxiMobile/app/src/main/res/layout/activity_user_notifications.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/activity_user_notifications.xml
@@ -16,7 +16,7 @@
         android:id="@+id/nEmpty"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="No notifications."
+        android:text="@string/notifications_empty"
         android:visibility="gone"
         android:paddingTop="24dp"/>
 

--- a/android/TaxiMobile/app/src/main/res/menu/nav_menu_user.xml
+++ b/android/TaxiMobile/app/src/main/res/menu/nav_menu_user.xml
@@ -19,7 +19,7 @@
 
     <item
         android:id="@+id/nav_notifications"
-        android:title="Notifications" />
+        android:title="@string/menu_notifications" />
 
 
     <item

--- a/android/TaxiMobile/app/src/main/res/values/strings.xml
+++ b/android/TaxiMobile/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="menu_history">Ride history</string>
     <string name="menu_rate_ride">Rate ride</string>
     <string name="menu_live_tracking">Live Tracking</string>
+    <string name="menu_notifications">Notifications</string>
     <string name="menu_support">Support</string>
     <string name="menu_profile">Profile</string>
     <string name="menu_logout">Log out</string>
@@ -345,6 +346,28 @@
     <string name="admin_create_driver_error_invalid_seats">Seats must be a number between 1 and 9.</string>
 
     <string name="admin_create_driver_success">Driver created. Activation email sent to %1$s. Link valid: %2$dh.</string>
+
+    <string name="title_notifications">Notifications</string>
+    <string name="notifications_empty">No notifications.</string>
+
+    <string name="title_active_ride">Active ride</string>
+    <string name="title_ride_tracking">Ride tracking</string>
+    <string name="tracking_eta_fmt">ETA: %1$d min (%2$.2f km)</string>
+    <string name="tracking_status_fmt">Status: %1$s</string>
+    <string name="tracking_eta_empty">ETA: -</string>
+    <string name="tracking_status_empty">Status: -</string>
+    <string name="tracking_no_active_ride">No active ride</string>
+    <string name="tracking_load_failed">Tracking is not available.</string>
+    <string name="tracking_report_title">Report driver inconsistency</string>
+    <string name="tracking_report_cancel">Cancel</string>
+    <string name="tracking_report_send">Send</string>
+    <string name="tracking_report_inactive">No active ride</string>
+    <string name="tracking_report_sent">Report sent</string>
+
+    <string name="notif_channel_name">Ride updates</string>
+    <string name="notif_channel_description">Notifications about ride status updates.</string>
+    <string name="notif_default_title">Ride update</string>
+    <string name="notif_default_message">Open the app to view details.</string>
 
 
 </resources>

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcRideRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcRideRepository.java
@@ -220,7 +220,7 @@ public class JdbcRideRepository implements RideRepository {
                             .param("rideId", rideId)
                             .query((rs2, rn) -> new RideReportDto(
                                     rs2.getString("description"),
-                                    rs2.getTimestamp("createdAt")
+                                    rs2.getTimestamp("created_at")
                             ))
                             .list();
 

--- a/backend/backend/src/main/java/org/example/backend/service/MailQueueService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/MailQueueService.java
@@ -2,14 +2,19 @@ package org.example.backend.service;
 
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class MailQueueService {
 
     private final JavaMailSender mailSender;
+    private static final Pattern LINK_PATTERN = Pattern.compile("(https?://\\S+|taximobile://\\S+)");
 
     public MailQueueService(JavaMailSender mailSender) {
         this.mailSender = mailSender;
@@ -25,12 +30,15 @@ public class MailQueueService {
 
         new Thread(() -> {
             for (SimpleMailMessage msg : messages) {
+                if (msg == null) {
+                    continue;
+                }
                 try {
-                    mailSender.send(msg);
-                    System.out.println("MAIL SENT TO: " + String.join(",", msg.getTo()));
+                    sendAsMime(msg);
+                    System.out.println("MAIL SENT TO: " + recipientsOf(msg));
                 } catch (Exception ex) {
                     System.out.println(
-                            "MAIL FAILED TO: " + String.join(",", msg.getTo()) +
+                            "MAIL FAILED TO: " + recipientsOf(msg) +
                                     " | " + ex.getMessage()
                     );
                 }
@@ -44,6 +52,52 @@ public class MailQueueService {
                 }
             }
         }).start();
+    }
+
+    private void sendAsMime(SimpleMailMessage source) throws Exception {
+        var mime = mailSender.createMimeMessage();
+        var helper = new MimeMessageHelper(mime, true, "UTF-8");
+
+        if (source.getFrom() != null && !source.getFrom().isBlank()) helper.setFrom(source.getFrom());
+        if (source.getTo() != null && source.getTo().length > 0) helper.setTo(source.getTo());
+        if (source.getCc() != null && source.getCc().length > 0) helper.setCc(source.getCc());
+        if (source.getBcc() != null && source.getBcc().length > 0) helper.setBcc(source.getBcc());
+        if (source.getReplyTo() != null && !source.getReplyTo().isBlank()) helper.setReplyTo(source.getReplyTo());
+        if (source.getSubject() != null) helper.setSubject(source.getSubject());
+
+        String plainText = source.getText() == null ? "" : source.getText();
+        helper.setText(plainText, toHtml(plainText));
+
+        mailSender.send(mime);
+    }
+
+    private String toHtml(String plainText) {
+        StringBuilder out = new StringBuilder();
+        Matcher matcher = LINK_PATTERN.matcher(plainText);
+        int cursor = 0;
+
+        while (matcher.find()) {
+            out.append(escapeAndBreaks(plainText.substring(cursor, matcher.start())));
+            String url = matcher.group(1);
+            String escapedUrl = HtmlUtils.htmlEscape(url);
+            out.append("<a href=\"").append(escapedUrl).append("\">")
+                    .append(escapedUrl)
+                    .append("</a>");
+            cursor = matcher.end();
+        }
+
+        out.append(escapeAndBreaks(plainText.substring(cursor)));
+        return "<html><body>" + out + "</body></html>";
+    }
+
+    private String escapeAndBreaks(String text) {
+        return HtmlUtils.htmlEscape(text).replace("\n", "<br/>");
+    }
+
+    private String recipientsOf(SimpleMailMessage msg) {
+        String[] to = msg.getTo();
+        if (to == null || to.length == 0) return "<no-recipient>";
+        return String.join(",", to);
     }
 
 }

--- a/backend/backend/src/main/java/org/example/backend/service/MailService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/MailService.java
@@ -12,6 +12,8 @@ public class MailService {
     private final JavaMailSender mailSender;
     @Value("${app.frontend.base-url:http://localhost:4200}")
     private String frontendBaseUrl;
+    @Value("${app.mobile.deep-link-base:taximobile://user/ride-tracking}")
+    private String mobileDeepLinkBase;
 
 
     @Value("${spring.mail.from}")
@@ -40,6 +42,8 @@ public class MailService {
             String startAddress,
             String destinationAddress
     ) {
+        String webTrackingLink = buildWebTrackingLink(rideId);
+        String mobileTrackingLink = buildMobileTrackingLink(rideId);
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom(from);
         msg.setTo(to);
@@ -49,15 +53,19 @@ public class MailService {
                         "Ride ID: " + rideId + "\n" +
                         "From: " + startAddress + "\n" +
                         "To: " + destinationAddress + "\n\n" +
-                        "You can rate the ride within 3 days."
+                        "You can rate the ride within 3 days.\n\n" +
+                        "Web details: " + webTrackingLink + "\n" +
+                        "Open in Android app: " + mobileTrackingLink + "\n"
         );
         return msg;
     }
 
 
     public SimpleMailMessage buildRideAcceptedEmail(
-            String to, Long rideId, String startAddress, String destinationAddress, String trackingLink
+            String to, Long rideId, String startAddress, String destinationAddress
     ) {
+        String webTrackingLink = buildWebTrackingLink(rideId);
+        String mobileTrackingLink = buildMobileTrackingLink(rideId);
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom(from);
         msg.setTo(to);
@@ -67,7 +75,8 @@ public class MailService {
                         "Ride ID: " + rideId + "\n" +
                         "From: " + startAddress + "\n" +
                         "To: " + destinationAddress + "\n\n" +
-                        "Track the ride: " + trackingLink + "\n"
+                        "Track the ride (web): " + webTrackingLink + "\n" +
+                        "Open in Android app: " + mobileTrackingLink + "\n"
         );
         return msg;
     }
@@ -76,19 +85,21 @@ public class MailService {
             String to,
             Long rideId,
             String startAddress,
-            String destinationAddress,
-            String trackingLink
+            String destinationAddress
     ) {
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom(from);
         msg.setTo(to);
         msg.setSubject("Ride accepted");
+        String webTrackingLink = buildWebTrackingLink(rideId);
+        String mobileTrackingLink = buildMobileTrackingLink(rideId);
         msg.setText(
                 "You were added to a ride and a driver has accepted it.\n\n" +
                         "Ride ID: " + rideId + "\n" +
                         "From: " + startAddress + "\n" +
                         "To: " + destinationAddress + "\n\n" +
-                        "Track the ride: " + trackingLink + "\n"
+                        "Track the ride (web): " + webTrackingLink + "\n" +
+                        "Open in Android app: " + mobileTrackingLink + "\n"
         );
         mailSender.send(msg);
     }
@@ -100,6 +111,8 @@ public class MailService {
             String startAddress,
             String destinationAddress
     ) {
+        String webTrackingLink = buildWebTrackingLink(rideId);
+        String mobileTrackingLink = buildMobileTrackingLink(rideId);
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom(from);
         msg.setTo(to);
@@ -109,7 +122,9 @@ public class MailService {
                 "Ride ID: " + rideId + "\n" +
                 "From: " + startAddress + "\n" +
                 "To: " + destinationAddress + "\n\n" +
-                "You can rate the ride within 3 days."
+                "You can rate the ride within 3 days.\n\n" +
+                "Web details: " + webTrackingLink + "\n" +
+                "Open in Android app: " + mobileTrackingLink + "\n"
         );
 
         mailSender.send(msg);
@@ -134,4 +149,16 @@ public class MailService {
 
     System.out.println(">>> MAIL SENT SUCCESSFULLY");
 }
+
+    private String buildWebTrackingLink(Long rideId) {
+        return frontendBaseUrl + "/user/ride-tracking?rideId=" + rideId;
+    }
+
+    private String buildMobileTrackingLink(Long rideId) {
+        String base = mobileDeepLinkBase == null ? "" : mobileDeepLinkBase.trim();
+        if (base.isEmpty()) {
+            base = "taximobile://user/ride-tracking";
+        }
+        return base + (base.contains("?") ? "&" : "?") + "rideId=" + rideId;
+    }
 }

--- a/backend/backend/src/main/java/org/example/backend/service/RideOrderService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/RideOrderService.java
@@ -8,7 +8,6 @@ import org.example.backend.exception.BlockedUserException;
 import org.example.backend.exception.NoAvailableDriverException;
 import org.example.backend.osrm.OsrmClient;
 import org.example.backend.repository.*;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
@@ -37,10 +36,6 @@ public class RideOrderService {
     private final NotificationService notificationService;
     private final MailQueueService mailQueueService;
     private final PricingService pricingService;
-
-
-    @Value("${app.frontend.base-url:http://localhost:4200}")
-    private String frontendBaseUrl;
 
     public RideOrderService(
             OsrmClient osrmClient,
@@ -302,7 +297,6 @@ public class RideOrderService {
 
         String startAddr = safeTrim(start.getAddress());
         String destAddr  = safeTrim(dest.getAddress());
-        String trackingLink = frontendBaseUrl + "/user/ride-tracking?rideId=" + rideId;
 
         List<SimpleMailMessage> out = new ArrayList<>();
         for (RidePassengerRepository.PassengerRow p : passengers) {
@@ -313,8 +307,7 @@ public class RideOrderService {
                                 email,
                                 rideId,
                                 startAddr,
-                                destAddr,
-                                trackingLink
+                                destAddr
                         )
                 );
             }

--- a/backend/backend/src/main/resources/application-mailtrap.properties
+++ b/backend/backend/src/main/resources/application-mailtrap.properties
@@ -1,7 +1,7 @@
 spring.mail.host=sandbox.smtp.mailtrap.io
 spring.mail.port=587
-spring.mail.username=31727ff6c3e396
-spring.mail.password=cde1b6c382c3bf
+spring.mail.username=Username
+spring.mail.password=password
 
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/backend/src/main/resources/application.properties
+++ b/backend/backend/src/main/resources/application.properties
@@ -33,6 +33,7 @@ logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.boot.context.config=DEBUG
 
 app.frontend.base-url=http://localhost:4200
+app.mobile.deep-link-base=${APP_MOBILE_DEEP_LINK_BASE:taximobile://user/ride-tracking}
 # ===== JWT =====
 app.jwt.secret=${APP_JWT_SECRET:dev-only-change-me-dev-only-change-me-123456}
 app.jwt.ttl-minutes=${APP_JWT_TTL_MINUTES:120}


### PR DESCRIPTION
Enable opening ride tracking from emails and notifications and add foreground notification polling.

- Android: register taximobile://user/ride-tracking intent in AndroidManifest and handle deep links in PublicHomeMapActivity (route based on auth/role). LoginActivity accepts a post-login ride id and forwards to PassengerActiveRideActivity when needed.
- PassengerActiveRideActivity: support specific-ride mode (by rideId), read-only mode, updated polling behavior, improved UI texts and strings, and report dialog localization.
- Notifications: add NotificationLinkRouter to resolve links to intents, add UserForegroundNotificationPoller to poll server and post system notifications, add notification icon and strings, update UserBaseActivity to request POST_NOTIFICATIONS permission and manage the poller, and make UserNotificationsActivity open routed targets.
- API/Repo: add RideActiveApi#getRideTrackingById and RideActiveRepository#getTrackingByRideId to fetch tracking for a specific ride.
- Backend: MailQueueService now sends MIME HTML emails with basic auto-linking, MailService builds both web and mobile deep links (app.mobile.deep-link-base property), RideOrderService adapted to MailService changes, and a small JDBC timestamp column name fix.
- Config: add app.mobile.deep-link-base property and update mailtrap properties.

These changes let emails and notifications include deep links that open the app directly to ride tracking, and provide in-app foreground notifications for new user notifications.
Closes #108 