### PR TITLE
Remove SimpleJdbcInsert init from constructor

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcDriverRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcDriverRepository.java
@@ -13,10 +13,6 @@ public class JdbcDriverRepository implements DriverRepository {
 
     public JdbcDriverRepository(JdbcClient jdbc) {
         this.jdbc = jdbc;
-        this.driverInsert = new SimpleJdbcInsert(dataSource)
-                .withTableName("drivers")
-                .usingColumns("user_id", "available")
-                .usingGeneratedKeyColumns("id");
     }
 
     @Override


### PR DESCRIPTION
Remove the immediate creation of driverInsert in JdbcDriverRepository's constructor. Deleted the SimpleJdbcInsert setup that referenced dataSource and configured table "drivers" with columns (user_id, available) and generated key "id". Initialization can be handled elsewhere (e.g. lazily or in a different component) to avoid the direct dataSource dependency in the constructor.
Closes #115 