### PR TITLE
Add driver/user support routes and update nav links

### DIFF
--- a/frontend/ddn-frontend/src/app/app.routes.spec.ts
+++ b/frontend/ddn-frontend/src/app/app.routes.spec.ts
@@ -1,0 +1,27 @@
+import { Route } from '@angular/router';
+
+import { routes } from './app.routes';
+import { CHAT_DS } from './api/chat/chat.datasource';
+import { ChatHttpDataSource } from './api/chat/chat.http.datasource';
+
+function findChildRoute(parentPath: string, childPath: string): Route | undefined {
+  const parent = routes.find((route) => route.path === parentPath);
+  return parent?.children?.find((route) => route.path === childPath);
+}
+
+describe('app routes', () => {
+  it('should register driver support route', () => {
+    const route = findChildRoute('driver', 'support');
+    expect(route).toBeTruthy();
+    expect(typeof route?.loadComponent).toBe('function');
+  });
+
+  it('should use chat datasource provider for driver support', () => {
+    const route = findChildRoute('driver', 'support');
+    const providers = (route?.providers ?? []) as Array<{ provide?: unknown; useClass?: unknown }>;
+    const chatProvider = providers.find((provider) => provider.provide === CHAT_DS);
+
+    expect(chatProvider).toBeTruthy();
+    expect(chatProvider?.useClass).toBe(ChatHttpDataSource);
+  });
+});

--- a/frontend/ddn-frontend/src/app/app.routes.ts
+++ b/frontend/ddn-frontend/src/app/app.routes.ts
@@ -136,6 +136,11 @@ export const routes: Routes = [
     canActivate: [authGuard, roleGuard],
     data: { roles: ['DRIVER'] },
     children: [
+      {
+        path: 'support',
+        loadComponent: () => import('./pages/user/user-chat/user-chat').then(m => m.UserChat),
+        providers: [{ provide: CHAT_DS, useClass: ChatHttpDataSource }],
+      },
       { path: 'home', component: DriverHomeComponent },
       {
         path: 'active-ride',

--- a/frontend/ddn-frontend/src/app/components/navbar/navbar.html
+++ b/frontend/ddn-frontend/src/app/components/navbar/navbar.html
@@ -18,7 +18,7 @@
   </div>
 
   <div class="nav-center">
-    <div class="panic-btn" routerLink="/support" routerLinkActive="active-panic">
+    <div class="panic-btn" routerLink="/driver/support" routerLinkActive="active-panic">
       <img src="panic.svg" alt="panic" />
     </div>
   </div>
@@ -28,7 +28,7 @@
       {{ (driverAvailable$ | async) ? 'Available' : 'Busy' }}
     </div>
 
-    <a class="nav-link" routerLink="/support" routerLinkActive="active">
+    <a class="nav-link" routerLink="/driver/support" routerLinkActive="active">
       Support
     </a>
 

--- a/frontend/ddn-frontend/src/app/components/navbar/navbar.spec.ts
+++ b/frontend/ddn-frontend/src/app/components/navbar/navbar.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter, RouterLink } from '@angular/router';
 
 import { NavbarComponent } from './navbar';
 
@@ -8,16 +10,26 @@ describe('Navbar', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavbarComponent]
+      imports: [NavbarComponent],
+      providers: [provideRouter([])],
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(NavbarComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
     await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should point support links to /driver/support', () => {
+    const links = fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink).urlTree?.toString());
+
+    expect(links.filter((path) => path === '/driver/support').length).toBe(2);
   });
 });

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.html
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.html
@@ -19,7 +19,7 @@
   </div>
 
   <div class="nav-center">
-    <div class="panic-btn" routerLink="/support" routerLinkActive="active-panic">
+    <div class="panic-btn" routerLink="/user/support" routerLinkActive="active-panic">
       <img src="panic.svg" alt="panic" />
     </div>
   </div>
@@ -59,4 +59,3 @@
       </button>
   </div>
 </nav>
-

--- a/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.spec.ts
+++ b/frontend/ddn-frontend/src/app/components/user-navbar/user-navbar.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter, RouterLink } from '@angular/router';
+import { of } from 'rxjs';
 
 import { UserNavbarComponent } from './user-navbar';
+import { NotificationApi } from '../../api/notifications/notification.api';
 
 describe('UserNavbar', () => {
   let component: UserNavbarComponent;
@@ -8,16 +12,36 @@ describe('UserNavbar', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [UserNavbarComponent]
+      imports: [UserNavbarComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: NotificationApi,
+          useValue: {
+            getUnreadCount: () => of(0),
+            getMy: () => of([]),
+            markRead: () => of(void 0),
+          },
+        },
+      ],
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(UserNavbarComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
     await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should point panic and support links to /user/support', () => {
+    const links = fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink).urlTree?.toString());
+
+    expect(links.filter((path) => path === '/user/support').length).toBe(2);
   });
 });


### PR DESCRIPTION
Register role-scoped support routes and update navigation/tests accordingly. Adds a new driver support child route that lazy-loads UserChat and provides CHAT_DS via ChatHttpDataSource; adds app.routes.spec.ts to verify the route, lazy load and provider. Updates navbar and user-navbar templates to point panic/support links to /driver/support and /user/support respectively. Updates navbar and user-navbar specs to use provideRouter, check router links, and mock NotificationApi for the user navbar component.
Closes #119 