### PR TITLE
Add scheduled ride handling & upcoming rides

### DIFF
--- a/backend/backend/src/main/java/org/example/backend/controller/DriverController.java
+++ b/backend/backend/src/main/java/org/example/backend/controller/DriverController.java
@@ -50,6 +50,11 @@ public class DriverController {
         return ResponseEntity.ok(driverRideService.getAcceptedRides(getCurrentDriverId()));
     }
 
+    @GetMapping("/rides/upcoming")
+    public ResponseEntity<List<DriverRideDetailsResponseDto>> getUpcomingRides() {
+        return ResponseEntity.ok(driverRideService.getUpcomingRides(getCurrentDriverId()));
+    }
+
     @PutMapping("/rides/{rideId}/start")
     public ResponseEntity<Void> startRide(@PathVariable Long rideId) {
         driverRideService.startRide(getCurrentDriverId(), rideId);

--- a/backend/backend/src/main/java/org/example/backend/repository/DriverMatchingRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/DriverMatchingRepository.java
@@ -1,5 +1,6 @@
 package org.example.backend.repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface DriverMatchingRepository {
@@ -26,6 +27,13 @@ public interface DriverMatchingRepository {
             int requiredSeats
     );
 
+    List<CandidateDriver> findAssignableDriversForScheduledRide(
+            String vehicleTypeLower,
+            boolean babyTransport,
+            boolean petTransport,
+            int requiredSeats
+    );
+
     List<FinishingSoonDriver> findDriversFinishingSoon(
             String vehicleTypeLower,
             boolean babyTransport,
@@ -37,4 +45,10 @@ public interface DriverMatchingRepository {
     boolean setDriverAvailable(Long driverId, boolean available);
 
     boolean tryClaimAvailableDriver(Long driverId);
+
+    boolean hasOpenImmediateRideConflictingWithSchedule(Long driverId, OffsetDateTime latestAllowedFinishAt);
+
+    boolean hasAssignedScheduledRideBefore(Long driverId, OffsetDateTime latestAllowedStartAt);
+
+    boolean hasScheduledRideInWindow(Long driverId, OffsetDateTime fromInclusive, OffsetDateTime toInclusive);
 }

--- a/backend/backend/src/main/java/org/example/backend/repository/DriverRideRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/DriverRideRepository.java
@@ -13,6 +13,7 @@ public interface DriverRideRepository {
     Optional<DriverRideDetailsResponseDto> findActiveRideDetails(Long driverId);
 
     List<DriverRideDetailsResponseDto> findAcceptedRides(Long driverId);
+    List<DriverRideDetailsResponseDto> findUpcomingRides(Long driverId);
     boolean startRide(Long driverId, Long rideId);
     boolean finishRide(Long driverId, Long rideId);
     boolean hasUpcomingAssignedRide(Long driverId);

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcDriverRideRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcDriverRideRepository.java
@@ -8,12 +8,15 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public class JdbcDriverRideRepository implements DriverRideRepository {
+
+    private static final int SCHEDULE_LOCK_MINUTES = 15;
 
     private final JdbcClient jdbc;
 
@@ -148,11 +151,22 @@ public class JdbcDriverRideRepository implements DriverRideRepository {
 
     @Override
     public List<DriverRideDetailsResponseDto> findAcceptedRides(Long driverId) {
+        return findOpenRidesByStatuses(driverId, List.of("ACCEPTED"));
+    }
+
+    @Override
+    public List<DriverRideDetailsResponseDto> findUpcomingRides(Long driverId) {
+        return findOpenRidesByStatuses(driverId, List.of("SCHEDULED", "ACCEPTED"));
+    }
+
+    private List<DriverRideDetailsResponseDto> findOpenRidesByStatuses(Long driverId, List<String> statuses) {
+        if (statuses == null || statuses.isEmpty()) return List.of();
+
         String sql = """
             select r.id
             from rides r
             where r.driver_id = :driverId
-              and r.status = 'ACCEPTED'
+              and r.status in (:statuses)
               and r.ended_at is null
               and r.canceled = false
             order by coalesce(r.scheduled_at, r.created_at) asc
@@ -160,6 +174,7 @@ public class JdbcDriverRideRepository implements DriverRideRepository {
 
         List<Long> rideIds = jdbc.sql(sql)
                 .param("driverId", driverId)
+                .param("statuses", statuses)
                 .query(Long.class)
                 .list();
 
@@ -214,15 +229,25 @@ public class JdbcDriverRideRepository implements DriverRideRepository {
 
     @Override
     public boolean hasUpcomingAssignedRide(Long driverId) {
+        OffsetDateTime lockBoundary = OffsetDateTime.now().plusMinutes(SCHEDULE_LOCK_MINUTES);
+
         Integer count = jdbc.sql("""
             select count(1)
             from rides
             where driver_id = :driverId
               and ended_at is null
               and canceled = false
-              and status in ('SCHEDULED', 'ACCEPTED', 'ACTIVE')
+              and (
+                    status in ('ACCEPTED', 'ACTIVE')
+                    or (
+                        status = 'SCHEDULED'
+                        and scheduled_at is not null
+                        and scheduled_at <= :lockBoundary
+                    )
+              )
         """)
                 .param("driverId", driverId)
+                .param("lockBoundary", lockBoundary)
                 .query(Integer.class)
                 .single();
 

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcRideOrderRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcRideOrderRepository.java
@@ -16,7 +16,7 @@ public class JdbcRideOrderRepository implements RideOrderRepository {
     }
 
     @Override
-    public boolean userHasActiveRide(String email) {
+    public boolean userHasOpenImmediateRide(String email) {
         Boolean exists = jdbc.sql("""
             select exists (
                 select 1
@@ -25,10 +25,92 @@ public class JdbcRideOrderRepository implements RideOrderRepository {
                 where lower(rp.email) = lower(:email)
                   and r.canceled = false
                   and r.ended_at is null
-                  and r.status in ('ACCEPTED', 'ACTIVE', 'SCHEDULED')
+                  and r.status in ('ACCEPTED', 'ACTIVE')
             )
         """)
                 .param("email", email)
+                .query(Boolean.class)
+                .single();
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    @Override
+    public boolean userHasOpenImmediateRideConflictingWithSchedule(String email, OffsetDateTime latestAllowedFinishAt) {
+        Boolean exists = jdbc.sql("""
+            select exists (
+                select 1
+                from rides r
+                join ride_passengers rp on rp.ride_id = r.id
+                where lower(rp.email) = lower(:email)
+                  and r.canceled = false
+                  and r.ended_at is null
+                  and r.status in ('ACCEPTED', 'ACTIVE')
+                  and (
+                        case
+                            when r.status = 'ACTIVE' then
+                                now() + (
+                                    greatest(
+                                        0,
+                                        coalesce(r.est_duration_seconds, 86400)
+                                        - extract(epoch from (now() - coalesce(r.started_at, now())))
+                                    ) * interval '1 second'
+                                )
+                            else
+                                now() + (coalesce(r.est_duration_seconds, 86400) * interval '1 second')
+                        end
+                  ) > :latestAllowedFinishAt
+            )
+        """)
+                .param("email", email)
+                .param("latestAllowedFinishAt", latestAllowedFinishAt)
+                .query(Boolean.class)
+                .single();
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    @Override
+    public boolean userHasScheduledRideBefore(String email, OffsetDateTime latestAllowedStartAt) {
+        Boolean exists = jdbc.sql("""
+            select exists (
+                select 1
+                from rides r
+                join ride_passengers rp on rp.ride_id = r.id
+                where lower(rp.email) = lower(:email)
+                  and r.canceled = false
+                  and r.ended_at is null
+                  and r.status in ('SCHEDULED', 'ACCEPTED')
+                  and r.scheduled_at is not null
+                  and r.scheduled_at < :latestAllowedStartAt
+            )
+        """)
+                .param("email", email)
+                .param("latestAllowedStartAt", latestAllowedStartAt)
+                .query(Boolean.class)
+                .single();
+
+        return Boolean.TRUE.equals(exists);
+    }
+
+    @Override
+    public boolean userHasScheduledRideInWindow(String email, OffsetDateTime fromInclusive, OffsetDateTime toInclusive) {
+        Boolean exists = jdbc.sql("""
+            select exists (
+                select 1
+                from rides r
+                join ride_passengers rp on rp.ride_id = r.id
+                where lower(rp.email) = lower(:email)
+                  and r.canceled = false
+                  and r.ended_at is null
+                  and r.status in ('SCHEDULED', 'ACCEPTED')
+                  and r.scheduled_at is not null
+                  and r.scheduled_at between :fromInclusive and :toInclusive
+            )
+        """)
+                .param("email", email)
+                .param("fromInclusive", fromInclusive)
+                .param("toInclusive", toInclusive)
                 .query(Boolean.class)
                 .single();
 
@@ -79,9 +161,10 @@ public class JdbcRideOrderRepository implements RideOrderRepository {
     }
 
     @Override
-    public Long insertScheduledRideReturningId(OffsetDateTime scheduledAt, String startAddress, String destinationAddress,
+    public Long insertScheduledRideReturningId(Long driverId, OffsetDateTime scheduledAt, String startAddress, String destinationAddress,
                                                BigDecimal price, String status, double startLat, double startLng,
-                                               double destLat, double destLng, double distanceMeters, double durationSeconds,
+                                               double destLat, double destLng, Double carLat, Double carLng,
+                                               double distanceMeters, double durationSeconds,
                                                String vehicleType, boolean babyTransport, boolean petTransport, int requiredSeats) {
 
         return jdbc.sql("""
@@ -96,17 +179,18 @@ public class JdbcRideOrderRepository implements RideOrderRepository {
                 vehicle_type, baby_transport, pet_transport, required_seats
             )
             values (
-                null, :scheduledAt,
+                :driverId, :scheduledAt,
                 :startAddress, :destinationAddress,
                 :price, :status,
                 :startLat, :startLng, :destLat, :destLng,
-                null, null,
+                :carLat, :carLng,
                 :dist, :dur,
                 false,
                 :vehicleType, :baby, :pet, :seats
             )
             returning id
         """)
+                .param("driverId", driverId)
                 .param("scheduledAt", scheduledAt)
                 .param("startAddress", startAddress)
                 .param("destinationAddress", destinationAddress)
@@ -116,6 +200,8 @@ public class JdbcRideOrderRepository implements RideOrderRepository {
                 .param("startLng", startLng)
                 .param("destLat", destLat)
                 .param("destLng", destLng)
+                .param("carLat", carLat)
+                .param("carLng", carLng)
                 .param("dist", distanceMeters)
                 .param("dur", durationSeconds)
                 .param("vehicleType", vehicleType)

--- a/backend/backend/src/main/java/org/example/backend/repository/JdbcScheduledRideRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/JdbcScheduledRideRepository.java
@@ -20,6 +20,7 @@ public class JdbcScheduledRideRepository implements ScheduledRideRepository {
         String sql = """
             select
                 r.id as ride_id,
+                r.driver_id,
                 r.scheduled_at,
                 r.start_address, r.start_lat, r.start_lng,
                 r.destination_address, r.dest_lat, r.dest_lng,
@@ -29,12 +30,11 @@ public class JdbcScheduledRideRepository implements ScheduledRideRepository {
                 r.required_seats
             from rides r
             where r.status = 'SCHEDULED'
-              and r.driver_id is null
               and r.canceled = false
               and r.ended_at is null
+              and r.started_at is null
               and r.scheduled_at is not null
               and r.scheduled_at <= now() + (:minutesAhead * interval '1 minute')
-              and r.scheduled_at > now() - interval '1 minute'
             order by r.scheduled_at asc
         """;
 
@@ -42,6 +42,7 @@ public class JdbcScheduledRideRepository implements ScheduledRideRepository {
                 .param("minutesAhead", minutesAhead)
                 .query((rs, rowNum) -> new ScheduledRideRow(
                         rs.getLong("ride_id"),
+                        (Long) rs.getObject("driver_id"),
                         rs.getObject("scheduled_at", OffsetDateTime.class),
                         rs.getString("start_address"),
                         rs.getDouble("start_lat"),

--- a/backend/backend/src/main/java/org/example/backend/repository/RideOrderRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/RideOrderRepository.java
@@ -5,7 +5,13 @@ import java.time.OffsetDateTime;
 
 public interface RideOrderRepository {
 
-    boolean userHasActiveRide(String email);
+    boolean userHasOpenImmediateRide(String email);
+
+    boolean userHasOpenImmediateRideConflictingWithSchedule(String email, OffsetDateTime latestAllowedFinishAt);
+
+    boolean userHasScheduledRideBefore(String email, OffsetDateTime latestAllowedStartAt);
+
+    boolean userHasScheduledRideInWindow(String email, OffsetDateTime fromInclusive, OffsetDateTime toInclusive);
 
     Long insertRideReturningId(
             Long driverId,
@@ -22,6 +28,7 @@ public interface RideOrderRepository {
     );
 
     Long insertScheduledRideReturningId(
+            Long driverId,
             OffsetDateTime scheduledAt,
             String startAddress,
             String destinationAddress,
@@ -29,6 +36,7 @@ public interface RideOrderRepository {
             String status,
             double startLat, double startLng,
             double destLat, double destLng,
+            Double carLat, Double carLng,
             double distanceMeters,
             double durationSeconds,
             String vehicleType,

--- a/backend/backend/src/main/java/org/example/backend/repository/ScheduledRideRepository.java
+++ b/backend/backend/src/main/java/org/example/backend/repository/ScheduledRideRepository.java
@@ -7,6 +7,7 @@ public interface ScheduledRideRepository {
 
     record ScheduledRideRow(
             Long rideId,
+            Long driverId,
             OffsetDateTime scheduledAt,
             String startAddress,
             double startLat,

--- a/backend/backend/src/main/java/org/example/backend/service/DriverRideService.java
+++ b/backend/backend/src/main/java/org/example/backend/service/DriverRideService.java
@@ -59,6 +59,10 @@ public class DriverRideService {
         return repository.findAcceptedRides(driverId);
     }
 
+    public List<DriverRideDetailsResponseDto> getUpcomingRides(Long driverId) {
+        return repository.findUpcomingRides(driverId);
+    }
+
     public void startRide(Long driverId, Long rideId) {
         boolean ok = repository.startRide(driverId, rideId);
         if (!ok) {

--- a/backend/backend/src/test/java/org/example/backend/repository/JdbcDriverRideRepositoryFinishTest.java
+++ b/backend/backend/src/test/java/org/example/backend/repository/JdbcDriverRideRepositoryFinishTest.java
@@ -339,6 +339,24 @@ class JdbcDriverRideRepositoryFinishTest {
     }
 
     @Test
+    void hasUpcomingAssignedRide_shouldReturnTrue_whenScheduledRideIsWithinLockWindow() {
+        insertRide(304L, DRIVER_ID, "SCHEDULED", false, null, null, OffsetDateTime.now().plusMinutes(10), null, null, 0, false);
+
+        boolean hasUpcoming = repository.hasUpcomingAssignedRide(DRIVER_ID);
+
+        assertTrue(hasUpcoming);
+    }
+
+    @Test
+    void hasUpcomingAssignedRide_shouldReturnFalse_whenScheduledRideIsOutsideLockWindow() {
+        insertRide(305L, DRIVER_ID, "SCHEDULED", false, null, null, OffsetDateTime.now().plusHours(2), null, null, 0, false);
+
+        boolean hasUpcoming = repository.hasUpcomingAssignedRide(DRIVER_ID);
+
+        assertFalse(hasUpcoming);
+    }
+
+    @Test
     void hasUpcomingAssignedRide_shouldReturnFalse_whenNoOpenAssignedRidesExist() {
         insertRide(
                 302L,

--- a/frontend/ddn-frontend/src/app/api/driver/driver-rides-http.datasource.ts
+++ b/frontend/ddn-frontend/src/app/api/driver/driver-rides-http.datasource.ts
@@ -29,6 +29,10 @@ export class DriverRidesHttpDataSource {
     return this.http.get<DriverRideDetails[]>(`${this.baseUrl}/driver/rides/accepted`);
   }
 
+  getUpcomingRides(): Observable<DriverRideDetails[]> {
+    return this.http.get<DriverRideDetails[]>(`${this.baseUrl}/driver/rides/upcoming`);
+  }
+
   startRide(rideId: number): Observable<void> {
     return this.http.put<void>(`${this.baseUrl}/driver/rides/${rideId}/start`, null);
   }

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-active-ride/driver-active-ride.spec.ts
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-active-ride/driver-active-ride.spec.ts
@@ -15,6 +15,7 @@ describe('DriverActiveRide', () => {
   let ridesApiMock: {
     getActiveRide: ReturnType<typeof vi.fn>;
     getAcceptedRides: ReturnType<typeof vi.fn>;
+    getUpcomingRides: ReturnType<typeof vi.fn>;
   };
   let driverStateMock: { setAvailable: ReturnType<typeof vi.fn> };
   let routerMock: { navigate: ReturnType<typeof vi.fn> };
@@ -42,6 +43,16 @@ describe('DriverActiveRide', () => {
     ridesApiMock = {
       getActiveRide: vi.fn().mockReturnValue(of(activeRide)),
       getAcceptedRides: vi.fn().mockReturnValue(
+        of([
+          {
+            ...activeRide,
+            rideId: 88,
+            status: 'ACCEPTED',
+            startedAt: null,
+          },
+        ])
+      ),
+      getUpcomingRides: vi.fn().mockReturnValue(
         of([
           {
             ...activeRide,
@@ -96,7 +107,7 @@ describe('DriverActiveRide', () => {
   });
 
   it('should prepare home navigation when there are no future rides', () => {
-    ridesApiMock.getAcceptedRides.mockReturnValueOnce(of([]));
+    ridesApiMock.getUpcomingRides.mockReturnValueOnce(of([]));
 
     component.finishRide();
 

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-active-ride/driver-active-ride.ts
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-active-ride/driver-active-ride.ts
@@ -119,14 +119,18 @@ export class DriverActiveRideComponent implements OnInit {
   }
 
   private preparePostFinishState(): void {
-    this.ridesApi.getAcceptedRides().pipe(take(1)).subscribe({
+    this.ridesApi.getUpcomingRides().pipe(take(1)).subscribe({
       next: (rides) => {
-        const nextRideId = rides?.length ? rides[0].rideId : null;
+        const nextRide = rides?.length ? rides[0] : null;
+        const nextRideId = nextRide?.rideId ?? null;
         if (nextRideId != null) {
-          this.driverState.setAvailable(false);
+          const readyToStart = nextRide?.status?.toUpperCase() === 'ACCEPTED';
+          this.driverState.setAvailable(!readyToStart);
           this.postFinishTarget = 'future';
           this.postFinishRideId = nextRideId;
-          this.postFinishMessage = 'Ride finished. Next assigned ride is ready.';
+          this.postFinishMessage = readyToStart
+            ? 'Ride finished. Next assigned ride is ready.'
+            : 'Ride finished. Upcoming scheduled ride is assigned.';
           return;
         }
 

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.css
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.css
@@ -51,18 +51,42 @@
 
 .assigned-item {
   width: 100%;
-  min-height: 36px;
+  min-height: 40px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 9px;
   background: rgba(0, 0, 0, 0.22);
   color: #ffffff;
   text-align: left;
-  padding: 7px 10px;
+  padding: 8px 10px;
   box-sizing: border-box;
   cursor: pointer;
   font-family: 'Montserrat', sans-serif;
   font-size: 11px;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.2;
+  overflow: hidden;
+}
+
+.assigned-item-id {
+  flex: 0 0 auto;
+  font-weight: 800;
+}
+
+.assigned-item-sep {
+  flex: 0 0 auto;
+  opacity: 0.8;
+}
+
+.assigned-item-route {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.95;
 }
 
 .assigned-item.active {

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.html
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.html
@@ -9,8 +9,11 @@
           *ngFor="let assignedRide of acceptedRides"
           [class.active]="assignedRide.rideId === ride?.rideId"
           (click)="selectRide(assignedRide.rideId)"
+          [title]="fullRouteLabel(assignedRide)"
         >
-          #{{ assignedRide.rideId }} · {{ assignedRide.startAddress }} → {{ assignedRide.destinationAddress }}
+          <span class="assigned-item-id">#{{ assignedRide.rideId }}</span>
+          <span class="assigned-item-sep">·</span>
+          <span class="assigned-item-route">{{ compactRouteLabel(assignedRide) }}</span>
         </button>
       </div>
 
@@ -48,7 +51,7 @@
         (click)="startRide()"
         [disabled]="!canStart()"
       >
-        {{ starting ? 'STARTING...' : 'START RIDE' }}
+        {{ starting ? 'STARTING...' : startLabel() }}
       </button>
 
       <button

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.spec.ts
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.spec.ts
@@ -14,7 +14,7 @@ describe('DriverFutureRides', () => {
   let fixture: ComponentFixture<DriverFutureRidesComponent>;
   let ridesApiMock: {
     getActiveRide: ReturnType<typeof vi.fn>;
-    getAcceptedRides: ReturnType<typeof vi.fn>;
+    getUpcomingRides: ReturnType<typeof vi.fn>;
     startRide: ReturnType<typeof vi.fn>;
   };
   let httpMock: { get: ReturnType<typeof vi.fn> };
@@ -57,7 +57,7 @@ describe('DriverFutureRides', () => {
   beforeEach(async () => {
     ridesApiMock = {
       getActiveRide: vi.fn().mockReturnValue(throwError(() => ({ status: 404 }))),
-      getAcceptedRides: vi.fn().mockReturnValue(of(acceptedRides)),
+      getUpcomingRides: vi.fn().mockReturnValue(of(acceptedRides)),
       startRide: vi.fn().mockReturnValue(of(void 0)),
     };
     httpMock = {

--- a/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.ts
+++ b/frontend/ddn-frontend/src/app/pages/driver/driver-future-rides/driver-future-rides.ts
@@ -106,7 +106,7 @@ export class DriverFutureRidesComponent implements AfterViewInit, OnDestroy {
     this.clearRouteFromMap();
 
     this.ridesApi
-      .getAcceptedRides()
+      .getUpcomingRides()
       .pipe(
         take(1),
         finalize(() => (this.loading = false))
@@ -258,7 +258,17 @@ export class DriverFutureRidesComponent implements AfterViewInit, OnDestroy {
   }
 
   canStart(): boolean {
-    return !!this.ride && !this.loading && !this.starting;
+    return (
+      !!this.ride &&
+      this.ride.status?.toUpperCase() === 'ACCEPTED' &&
+      !this.loading &&
+      !this.starting
+    );
+  }
+
+  startLabel(): string {
+    if (!this.ride) return 'START RIDE';
+    return this.ride.status?.toUpperCase() === 'ACCEPTED' ? 'START RIDE' : 'WAITING FOR START WINDOW';
   }
 
   startRide(): void {
@@ -289,8 +299,26 @@ export class DriverFutureRidesComponent implements AfterViewInit, OnDestroy {
     this.loadAcceptedRides();
   }
 
+  compactRouteLabel(ride: DriverRideDetails): string {
+    return `${this.compactAddress(ride.startAddress)} → ${this.compactAddress(ride.destinationAddress)}`;
+  }
+
+  fullRouteLabel(ride: DriverRideDetails): string {
+    return `${ride.startAddress ?? ''} → ${ride.destinationAddress ?? ''}`;
+  }
+
   private parseRideId(raw: string | null): number | null {
     const parsed = Number(raw);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  private compactAddress(address: string | null | undefined): string {
+    const value = (address ?? '').replace(/\s+/g, ' ').trim();
+    if (!value) return '—';
+
+    const comma = value.indexOf(',');
+    const base = comma > 0 ? value.slice(0, comma) : value;
+    if (base.length <= 32) return base;
+    return `${base.slice(0, 31)}…`;
   }
 }


### PR DESCRIPTION
Introduce support for scheduled rides and upcoming-ride handling across backend and frontend. Added /driver/rides/upcoming endpoint and DriverRideRepository.findUpcomingRides; adjusted driver ride queries to respect a schedule lock window. Extended repositories (DriverMatching, RideOrder, ScheduledRide) and JDBC implementations with new checks for conflicting immediate/scheduled rides, driver assignment queries, and persisted driver/car location for scheduled rides. RideOrderService now enforces passenger conflict checks, finds/reserves drivers for scheduled bookings, and applies a schedule buffer when evaluating availability; ScheduledRideAssignmentService now activates pre-assigned drivers and increases the assign-ahead window. Frontend updated to fetch upcoming rides, adapt UI labels and start-button logic, and tests added/updated for the new behavior.

Closes #132 