### PR TITLE
Bump Testcontainers to 1.21.4

### DIFF
--- a/backend/backend/pom.xml
+++ b/backend/backend/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <testcontainers.version>1.20.5</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Update the testcontainers.version property in backend/backend/pom.xml from 1.20.5 to 1.21.4 to pick up the fixes and improvements in the newer Testcontainers release.