### PR TITLE
Add live auto-refresh & better start errors

### DIFF
--- a/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/driver/data/DriverRideRepository.java
+++ b/android/TaxiMobile/app/src/main/java/com/example/taximobile/feature/driver/data/DriverRideRepository.java
@@ -7,9 +7,12 @@ import com.example.taximobile.core.network.ApiClient;
 import com.example.taximobile.feature.driver.data.dto.response.DriverRideDetailsResponseDto;
 import com.example.taximobile.feature.driver.data.dto.response.DriverRideHistoryResponseDto;
 
+import org.json.JSONObject;
+
 import java.util.Collections;
 import java.util.List;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -81,7 +84,10 @@ public class DriverRideRepository {
         api.startRide(rideId).enqueue(new Callback<Void>() {
             @Override
             public void onResponse(Call<Void> call, Response<Void> res) {
-                if (!res.isSuccessful()) { cb.onError("HTTP " + res.code()); return; }
+                if (!res.isSuccessful()) {
+                    cb.onError(extractErrorMessage(res));
+                    return;
+                }
                 cb.onSuccess();
             }
 
@@ -90,6 +96,28 @@ public class DriverRideRepository {
                 cb.onError(t.getMessage() != null ? t.getMessage() : "Network error");
             }
         });
+    }
+
+    private static String extractErrorMessage(Response<?> res) {
+        String fallback = "HTTP " + res.code();
+        ResponseBody body = null;
+        try {
+            body = res.errorBody();
+            if (body == null) return fallback;
+            String raw = body.string();
+            if (raw == null || raw.trim().isEmpty()) return fallback;
+
+            JSONObject obj = new JSONObject(raw);
+            String msg = obj.optString("message", null);
+            return msg != null && !msg.trim().isEmpty() ? msg.trim() : fallback;
+        } catch (Exception ignored) {
+            return fallback;
+        } finally {
+            try {
+                if (body != null) body.close();
+            } catch (Exception ignore) {
+            }
+        }
     }
 
     public void finishRide(long rideId, FinishCb cb) {

--- a/android/TaxiMobile/app/src/main/res/layout/activity_driver_home_start_ride.xml
+++ b/android/TaxiMobile/app/src/main/res/layout/activity_driver_home_start_ride.xml
@@ -102,6 +102,16 @@
             android:textStyle="bold"/>
 
         <TextView
+            android:id="@+id/dhLiveRefreshHint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/driver_home_live_refresh_hint"
+            android:textColor="@color/text_gray"
+            android:textSize="12sp"
+            android:visibility="gone" />
+
+        <TextView
             android:id="@+id/dhError"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/TaxiMobile/app/src/main/res/values/strings.xml
+++ b/android/TaxiMobile/app/src/main/res/values/strings.xml
@@ -339,8 +339,12 @@
     <string name="driver_start_ride_error_check_active">Unable to check active ride (%1$s)</string>
     <string name="driver_start_ride_error_load_assigned">Unable to load assigned rides (%1$s)</string>
     <string name="driver_start_ride_error_start">The ride start failed (%1$s)</string>
+    <string name="driver_start_ride_error_start_generic">The ride start failed. Please try again.</string>
+    <string name="driver_start_ride_error_too_far">You are not close enough to pickup. Move within %1$d m and try again. The map refreshes automatically.</string>
+    <string name="driver_start_ride_error_too_far_with_distance">You are about %1$d m from pickup. Move within %2$d m and try again. The map refreshes automatically.</string>
 
     <string name="driver_start_ride_checkpoints_label">Checkpoints:</string>
+    <string name="driver_home_live_refresh_hint">Live map updates every 2 seconds.</string>
     <string name="driver_home_no_accepted_ride">You currently do not have any accepted rides.</string>
     <string name="driver_home_open_future_rides">Open future rides</string>
     <string name="driver_future_rides_title">Driver – Future Rides</string>


### PR DESCRIPTION
Improve driver home UX: add automatic live refresh (2s) for accepted rides/tracking with handlers and in-flight flags to avoid duplicate requests; start/stop polling in onResume/onPause. Add distance-based start-ride error handling and generic fallback by extracting server error messages in DriverRideRepository. Add UI hint TextView and related strings, plus helper utilities (haversine distance, silent refresh paths) and minor flow fixes (clear map on ride changes, preserve initial load behavior). These changes provide clearer "too far from pickup" messaging and keep the map/tracking data up-to-date.